### PR TITLE
Update zQ methods and arguments

### DIFF
--- a/zq.js
+++ b/zq.js
@@ -129,23 +129,17 @@ export default class zQ {
 		return this.some(el => el.classList.contains(cname));
 	}
 
-	toggleClass(cname, condition) {
-		if (typeof condition === 'undefined') {
-			this.results.forEach(el => el.classList.toggle(cname));
+	toggleClass(cname, force) {
+		if (typeof force !== 'undefined') {
+			this.each(node => node.classList.toggle(cname, force));
 		} else {
-			this.results.forEach(el => el.classList.toggle(cname, condition));
+			this.each(node => node.classList.toggle(cname));
 		}
 		return this;
 	}
 
-	swapClass(cname1, cname2) {
-		this.each(node => {
-			if (node.classList.contains(cname1)) {
-				node.classList.replace(cname1, cname2);
-			} else if (node.classList.contains(cname2)) {
-				node.classList.replace(cname2, cname1);
-			}
-		});
+	replaceClass(cname1, cname2) {
+		this.each(node => node.classList.replace(cname1, cname2));
 		return this;
 	}
 


### PR DESCRIPTION
## Make zQ class methods / arguments more similar to `DOMTokenList`. Resolves #37

### List of significant changes made
-  Rename `swapClass` to `replaceClass`
-  Make `toggleClass` work like `classList.toggle`
- Use `DOMTokenList` methods internally

