### PR TITLE
Update `ready` method

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -3,9 +3,10 @@
 	<head>
 		<title>std-js test</title>
 		<meta charset="utf-8"/>
+		<base href="/test/" />
 		<link rel="icon" type="image/svg+xml" href="./javascript.svg" sizes="any"/>
 		<script type="application/javascript" src="https://cdn.polyfill.io/v2/polyfill.min.js" crossorigin="annonymous" async></script>
-		<script type="module" src="index.js" async></script>
+		<script type="module" src="./index.js" async></script>
 		<!-- <script type="application/javascript" src="./index.min.js" async nomodule></script> -->
 		<link rel="stylesheet" type="text/css" href="./index.css" />
 	</head>

--- a/test/index.js
+++ b/test/index.js
@@ -203,7 +203,8 @@ function showLocation() {
 	})();
 }
 
-$(self).load(async () => {
+
+$(document).ready(async () => {
 	if (document.createElement('details') instanceof HTMLUnknownElement) {
 		$('details > summary').click(() => {
 			this.parentElement.open = ! this.parentElement.open;

--- a/zq.js
+++ b/zq.js
@@ -230,11 +230,12 @@ export default class zQ {
 	}
 
 	ready(callback) {
+		this.on('DOMContentLoaded', callback);
 		if (document.readyState !== 'loading') {
-			callback();
-			return this;
+			this.each(node => {
+				node.dispatchEvent(new CustomEvent('DOMContentLoaded', {detail: null}));
+			});
 		}
-		return this.on('DOMContentLoaded', callback);
 	}
 
 	networkChange(callback) {

--- a/zq.js
+++ b/zq.js
@@ -231,9 +231,9 @@ export default class zQ {
 
 	ready(callback) {
 		this.on('DOMContentLoaded', callback);
-		if (document.readyState !== 'loading') {
+		if (document.readyState === 'complete') {
 			this.each(node => {
-				node.dispatchEvent(new CustomEvent('DOMContentLoaded', {detail: null}));
+				node.dispatchEvent(new Event('DOMContentLoaded'));
 			});
 		}
 	}


### PR DESCRIPTION
Use `dispatchEvent` to trigger `DOMContentLoaded` event if
`document.readState` is no longer "loading".

This way, event handlers run properly because the event is actually triggered and with all event target/properties set.