### PR TITLE
Misc updates to match current Element methods

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -4,6 +4,12 @@ export function $(selector, parent = document) {
 	return new zQ(selector, parent);
 }
 
+export function wait(ms) {
+	return new Promise(resolve => {
+		setTimeout(resolve, ms);
+	});
+}
+
 export function query(selector, node = document.documentElement) {
 	let results = Array.from(node.querySelectorAll(selector));
 	if (node.matches(selector)) {
@@ -99,107 +105,6 @@ export function parseResponse(resp) {
 		throw new TypeError(`Unsupported Content-Type: ${type}`);
 	}
 }
-// export function ajax(data) {
-// 	if ((typeof data.type !== 'undefined' && data.type.toLowerCase() === 'get') && (typeof data.request === 'string')) {
-// 		data.url += '?' + data.request;
-// 	}
-// 	if (typeof data.form !== 'undefined') {
-// 		if (typeof data.form === 'string') {
-// 			data.form = document.forms[data.form];
-// 		}
-// 		data.request = new FormData(data.form);
-// 		data.request.append('form', data.form.name);
-// 		data.request.append('nonce', sessionStorage.getItem('nonce'));
-// 		$('[data-input-name]').forEach(input => {
-// 			data.request.append(input.dataset.inputName, input.innerHTML);
-// 		});
-// 	}
-// 	if (typeof data.headers !== 'object') {
-// 		data.headers = {Accept: 'application/json'};
-// 	} else if (!('Accept' in data.headers)) {
-// 		data.headers.Accept = 'application/json';
-// 	}
-// 	return new Promise(function (success, fail) 	{
-// 		var resp;
-// 		/*https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise*/
-// 		if (typeof navigator.onLine !== 'boolean' || navigator.onLine) {
-// 			var req = new XMLHttpRequest(),
-// 				progress = document.createElement('progress');
-// 			if (('withCredentials' in req) && ('withCredentials' in data)) {
-// 				req.withCredentials = data.withCredentials;
-//
-// 			}
-// 			if (typeof data.contentType !== 'string') {
-// 				data.contentType = 'application/x-www-form-urlencoded';
-// 			}
-// 			document.body.appendChild(progress);
-// 			req.open(
-// 				data.type || 'POST',
-// 				data.url || document.baseURI,
-// 				data.async || true
-// 			);
-// 			if (typeof data.request === 'string') {
-// 				req.setRequestHeader('Content-type', data.contentType);
-// 			}
-// 			req.setRequestHeader('Accept', data.headers.Accept);
-// 			req.setRequestHeader('Request-Type', 'AJAX');
-// 			req.addEventListener('progress', event => {
-// 				if (event.lengthComputable) {
-// 					progress.value = event.loaded / event.total;
-// 				}
-// 			});
-// 			req.addEventListener('load', () => {
-// 				switch (req.getResponseHeader('Content-Type')) {
-// 				case 'application/json':
-// 					resp = JSON.parse(req.response);
-// 					break;
-//
-// 				case 'application/xml':
-// 				case 'text/xml':
-// 					resp = new DOMParser().parseFromString(req.response, 'application/xml');
-// 					break;
-//
-// 				case 'text/html':
-// 					resp = new DOMParser().parseFromString(req.response, 'text/html');
-// 					break;
-//
-// 				case 'image/svg':
-// 					resp = new DOMParser().parseFromString(req.response, 'image/svg+xml');
-// 					break;
-//
-// 				case 'text/plain':
-// 					resp = req.response;
-// 					break;
-// 				}
-// 				progress.parentElement.removeChild(progress);
-// 				if (req.status == 200) {
-// 					if (typeof data.history === 'string') {
-// 						history.pushState({}, document.title, data.history);
-// 					}
-// 					success(resp);
-// 				} else {
-// 					fail(Error(req.statusText));
-// 				}
-// 			});
-// 			req.addEventListener('error', function () {
-// 				progress.remove();
-// 				fail(Error('Network Error'));
-// 			});
-// 			if (typeof data.request !== 'undefined') {
-// 				req.send(data.request);
-// 			} else {
-// 				req.send();
-// 			}
-// 		} else {
-// 			notify({
-// 				title: 'Network:',
-// 				body: 'offline',
-// 				icon: 'images/icons/network-server.png'
-// 			});
-// 			fail('No Internet Connection');
-// 		}
-// 	});
-// }
 
 export function getLocation(options) {
 	/*https://developer.mozilla.org/en-US/docs/Web/API/Geolocation.getCurrentPosition*/

--- a/test/funcs.js
+++ b/test/funcs.js
@@ -17,19 +17,23 @@ import GitHub from '../GitHub.js';
 import Gravatar from '../Gravatar.js';
 
 export function loadHandler() {
-	// event.target.removeEventListener(event.type, loadHandler);
 	if (document.createElement('details') instanceof HTMLUnknownElement) {
 		$('details > summary').click(() => {
 			this.parentElement.open = ! this.parentElement.open;
 		});
 	}
+
+	mutations.init();
+
 	$('input[autocomplete="email"]:valid').each(input => {
 		input.before(new Gravatar(input.value));
 	});
+
 	$('input[autocomplete="username"]').each(input => {
 		input.before(GitHub.getAvatar(input.value));
 	});
-	$('form').submit(submit => {
+
+	$('form[name="contact-form"]').submit(submit => {
 		submit.preventDefault();
 		const form = new FormData(submit.target);
 		const data = {};
@@ -37,10 +41,10 @@ export function loadHandler() {
 			data[key] = form.get(key);
 		}
 		console.log(data);
-	});
-	$('form[name="contact-form"]').reset(reset => {
+	}).reset(reset => {
 		$('img', reset.target).remove();
 	});
+
 	$('input[autocomplete="email"]').change(input => {
 		$('img[src^="https://gravatar.com/"]', input.target.closest('fieldset')).remove();
 		if (input.target.validity.valid) {
@@ -48,48 +52,46 @@ export function loadHandler() {
 			input.target.before(grav);
 		}
 	});
+
 	$('input[autocomplete="username"]').change(input => {
 		$('img[src^="https://github.com"]', input.target.closest('fieldset')).remove();
 		if (input.target.validity.valid) {
 			input.target.before(GitHub.getAvatar(input.target.value));
 		}
 	});
+
 	$('form[name="openweather"]').submit(event => {
 		event.preventDefault();
 		const form = new FormData(event.target);
 		const weather = new OpenWeatherMap(KEYS.OpenWeatherMap, {units: form.get('units')});
 		weather.getFromZip(form.get('zip'), appendWeather);
 	});
+
 	$('#weather-loc').click(() => {
 		const weather = new OpenWeatherMap(KEYS.OpenWeatherMap);
 		weather.getFromCoords(appendWeather);
 	});
-	$('header h1').html = `<u>${document.title}</u>`;
-	mutations.init();
+
 	$('#gps-btn').click(showLocation);
+
 	$(document.body).watch(mutations.events, mutations.options, mutations.filter);
+
 	$('dialog').on('close', event => console.log(event.target.returnValue));
 
 	$('form[name="keybase-search"]').submit(keybaseSearch);
-	// console.info(Weather, SocialShare, WYSIWYG, FileUpload);
-	let url = new URL('fetch.json', location.origin);
-	let headers = new Headers();
-	headers.set('Accept', 'application/json');
-	fetch(url, {
-		headers
-	}).then(parseResponse).then(handleJSON).catch(reportError);
 
 	$('#vid-play').click(click => {
 		click.target.hidden = true;
 		getUserMedia();
 	});
-	$('#video-dialog').on('close', close => {
-		console.log(close);
-	});
 
 	$('#vid-canvas').click(click => {
 		open(click.target.toDataURL());
 	});
+
+	fetch(new URL('fetch.json', location.origin), {
+		headers: new Headers({Accept: 'application/json'})
+	}).then(parseResponse).then(handleJSON).catch(reportError);
 }
 
 function keybaseSearch(submit) {
@@ -208,8 +210,8 @@ function appendWeather(weather) {
 		// 	node.remove();
 		// }
 	});
-	document.body.appendChild(dialog);
-	$('dialog[open]').each(dialog => dialog.close());
+	document.body.append(dialog);
+	$('dialog[open]').close();
 	dialog.showModal();
 }
 

--- a/test/index.html
+++ b/test/index.html
@@ -10,7 +10,7 @@
 		<script type="application/javascript" src="./index.min.js" async="" nomodule=""></script>
 		<link rel="stylesheet" type="text/css" href="./index.min.css" />
 	</head>
-	<body class="no-js" contextmenu="context-menu">
+	<body class="no-js" contextmenu="context-menu" lang="en-us" dir="ltr">
 		<menu type="context" id="context-menu">
 			<menu label="Share on ...">
 				<menuitem label="Twitter" data-social-share="twitter"></menuitem>
@@ -56,13 +56,13 @@
 					</fieldset>
 					<fieldset>
 						<legend>Address</legend>
-						<input type="text" name="address[street]" autocomplete="street-address" placeholder="123 Some Street" pattern="\d+ [\w ]+" required=""/>
+						<input type="text" name="address[street]" autocomplete="street-address" placeholder="123 Some Street" pattern="\d+ [\w\.# ]+" required=""/>
 						<br />
 						<input type="text" name="address[city]" autocomplete="address-level2" placeholder="City" pattern="[A-z ]+" required=""/>
 						<span>, </span>
 						<input type="text" name="address[state]" autocomplete="address-level1" placeholder="State" pattern="[A-z ]+" required="" />
 						<br />
-						<input type="number" name="address[postal]" autocomplete="postal-code" placeholder="#####" required="" />
+						<input type="number" name="address[postal]" autocomplete="postal-code" placeholder="#####" min="10000" max="99999" required="" />
 						<br />
 					</fieldset>
 					<fieldset>
@@ -103,7 +103,7 @@
 				<button type="button" data-close="#weather-dialog">x</button>
 			</header>
 			<form name="openweather">
-				<input name="zip" type="number" min="10000" max="99999" placeholder="######" maxlength="5" required="" />
+				<input name="zip" type="number" min="10000" max="99999" placeholder="######" maxlength="5" autocomplete="postal-code" required="" />
 				<details>
 					<summary>Units</summary>
 					<label for="units-imperial">Imperial</label>

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,8 @@
 import './shims.js';
 import {loadHandler} from './funcs.js';
 import kbdShortcuts from '../kbd_shortcuts.js';
+import {$} from '../functions.js';
 
 document.body.classList.replace('no-js', 'js');
-self.addEventListener('keypress', kbdShortcuts);
-self.addEventListener('load', loadHandler, {once: true});
+
+$(document).ready(loadHandler).keypress(kbdShortcuts);

--- a/zq.js
+++ b/zq.js
@@ -65,11 +65,27 @@ export default class zQ {
 		return this.results.includes(node);
 	}
 
-	each(callback) {
-		this.results.forEach(callback);
+	each(...args) {
+		this.results.forEach(...args);
 		return this;
 	}
 
+	forEach(...args) {
+		this.results.forEach(...args);
+		return this;
+	}
+
+	*values() {
+		const len = this.results.length;
+		for(let i = 0; i < len; i++) {
+			yield this.results[i];
+		}
+	}
+
+	/**
+	 * Note: This is for `HTMLDialogElement.prototype.show`, not the inverse
+	 * of `hide`
+	 */
 	show() {
 		this.each(node => {
 			if ('show' in node) {
@@ -139,15 +155,15 @@ export default class zQ {
 
 	toggleClass(cname, force) {
 		if (typeof force !== 'undefined') {
-			this.each(node => node.classList.toggle(cname, force));
+			this.results.forEach(node => node.classList.toggle(cname, force));
 		} else {
-			this.each(node => node.classList.toggle(cname));
+			this.results.forEach(node => node.classList.toggle(cname));
 		}
 		return this;
 	}
 
 	replaceClass(cname1, cname2) {
-		this.each(node => node.classList.replace(cname1, cname2));
+		this.results.forEach(node => node.classList.replace(cname1, cname2));
 		return this;
 	}
 
@@ -161,25 +177,30 @@ export default class zQ {
 		return this;
 	}
 
-	hide() {
-		this.results.forEach(el => el.hidden = true);
+	hide(hidden = true) {
+		this.results.forEach(el => el.hidden = hidden);
 		return this;
 	}
 
-	unhide() {
-		this.results.forEach(el => el.hidden = false);
+	unhide(shown = true) {
+		return this.hide(!shown);
+	}
+
+	append(...nodes) {
+		this.results.forEach(el => el.append(...nodes));
 		return this;
 	}
 
-	delete() {
-		return this.remove();
+	prepend(...nodes) {
+		this.results.forEach(el => el.prepend(...nodes));
 	}
 
-	append(node) {
-		this.results.forEach(el => {
-			el.appendChild(document.importNode(node.cloneNode(true), true));
-		});
-		return this;
+	before(...nodes) {
+		this.results.forEach(el => el.before(...nodes));
+	}
+
+	after(...nodes) {
+		this.results.forEach(el => el.after(...nodes));
 	}
 
 	afterBegin(text) {
@@ -231,10 +252,12 @@ export default class zQ {
 
 	ready(callback, options = false) {
 		this.on('DOMContentLoaded', callback, options);
-		document.dispatchEvent(new Event('DOMContentLoaded'));
 		if (document.readyState !== 'loading') {
-			document.dispatchEvent(new Event('DOMContentLoaded'));
+			this.each(node => {
+				callback.bind(node)(new Event('DOMContentLoaded'));
+			});
 		}
+		return this;
 	}
 
 	networkChange(callback, options = false) {
@@ -350,10 +373,6 @@ export default class zQ {
 
 	updateready(callback, options = false) {
 		return this.on('updateready', callback, options);
-	}
-
-	DOMContentLoaded(callback, options = {once: true}) {
-		return this.on('DOMContentLoaded', callback, options);
 	}
 
 	load(callback, options = {once: true}) {


### PR DESCRIPTION
## Misc / minor updates, making more compatible with `Element.prototype`
### List of significant changes made
#### Added:
- `wait` function (resolves promise after given time in ms)
- forEach (identical to `each`)
- values generator (no need for keys)
- prepend, before, after

#### Changed:
- hide/unhide now take bool args
- append now uses `Element.protoype.append`
- re-worked `ready` method to fire after `document.readyState` passes
"loading"

#### Removed:
- delete (use `remove`)
- DOMContentLoaded (use `ready`)
