### PR TITLE
Add hashchange method

### DIFF
--- a/zq.js
+++ b/zq.js
@@ -415,6 +415,10 @@ export default class zQ {
 		return this.on('online', callback, options);
 	}
 
+	hashchange(callback, options = false) {
+		return this.on('hashchange' callback, options);
+	}
+
 	/*visibilitychange(callback) {
 		return this.on('visibilitychange', callback);
 	}*/

--- a/zq.js
+++ b/zq.js
@@ -416,7 +416,7 @@ export default class zQ {
 	}
 
 	hashchange(callback, options = false) {
-		return this.on('hashchange' callback, options);
+		return this.on('hashchange', callback, options);
 	}
 
 	/*visibilitychange(callback) {


### PR DESCRIPTION
Resolves #31
Allows for listening for `hashchange` events. Probably only
useful on `window`.