### PR TITLE
Bind ready callback to callback

### DIFF
--- a/zq.js
+++ b/zq.js
@@ -270,7 +270,7 @@ export default class zQ {
 		this.on('DOMContentLoaded', callback, ...args);
 		if (document.readyState !== 'loading') {
 			this.each(node => {
-				args[0].bind(node)(new Event('DOMContentLoaded'));
+				callback.bind(node)(new Event('DOMContentLoaded'));
 			});
 		}
 		return this;


### PR DESCRIPTION
Was binding to rest (`...args`)[1]
Fixes #53

## Fix incorrect binding in `zQ.ready`

### List of significant changes made
-  Use `callback.bind(node)` instead of `args[0].bind(node)`

