### PR TITLE
Fix missing event when adding event listeners

### DIFF
--- a/zq.js
+++ b/zq.js
@@ -262,7 +262,7 @@ export default class zQ {
 
 	/*==================== Listener Functions =================================*/
 	on(event, callback, ...args) {
-		this.each(node => node.addEventListener(callback, ...args));
+		this.each(node => node.addEventListener(event, callback, ...args));
 		return this;
 	}
 


### PR DESCRIPTION
## Add event argument. Fixes #55

### List of significant changes made
- Re-add `event` as   argument to `zq.on`

