### PR TITLE
Allow DOM operations to be async

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,5 +126,11 @@ $(document).ready(() => {
   $('[data-remove]').click(mutations.remove);
   $('[data-show-modal]').click(mutations.showModal);
   $(document.body).watch(mutations.events, mutations.options, mutations.filter);
+  // Note that many DOM operations happen asynchronously
+  $('.someClass').append('foo ', 'bar').then(nodes => {
+    /*...*/
+  }).catch(console.error);
+  document.querySelector('.someClass').textContent = 'baz ';
+  // Will most likely result in textContent of "baz foo bar"
 }, {once: true});
 ```

--- a/README.md
+++ b/README.md
@@ -122,14 +122,25 @@ import {$, wait} from './functions.js';
 import handleJSON from './json_response.js';
 import * as mutations from './mutations.js';
 
-$(document).ready(() => {
+// Note that almost all DOM operations are async
+$(document).ready(async () => {
   $('[data-remove]').click(mutations.remove);
   $('[data-show-modal]').click(mutations.showModal);
   $(document.body).watch(mutations.events, mutations.options, mutations.filter);
-  // Note that many DOM operations happen asynchronously
-  $('.someClass').append('foo ', 'bar').then(nodes => {
-    /*...*/
-  }).catch(console.error);
+
+  // Use promises
+  $('#container p').some(p => p.textContent.startsWith('Lorem impsum')).then(ipsum => {
+    if (ipsum) {
+      $('.no-ipum').hide();
+    }
+  });
+  // Or `await` results (Here, to search nodes by their text)
+  // In this example, `found` would be a regular `Element`
+  const found = await $('div').find(el => el.textContent.startsWith('Delete me'));
+  if (found) {
+	  found.remove();
+  }
+
   document.querySelector('.someClass').textContent = 'baz ';
   // Will most likely result in textContent of "baz foo bar"
 }, {once: true});

--- a/json_response.js
+++ b/json_response.js
@@ -1,238 +1,236 @@
 import {notify, query as $} from './functions.js';
 
-export default function handleJSON(json) {
-	return Promise.resolve().then(() => {
-		if(typeof json === 'string') {
-			json = JSON.parse(json.trim());
-		} else if(typeof json !== 'object') {
-			return false;
-		}
-		if('text' in json) {
-			Object.keys(json.text).forEach(key => {
-				document.querySelector(key).textContent = json.text[key];
-			});
-		}
-		if('html' in json) {
-			Object.keys(json.html).forEach(key => {
-				document.querySelector(key).innerHTML = json.html[key];
-			});
-		}
-		if('after' in json) {
-			Object.keys(json.after).forEach(key => {
-				document.querySelector(key).insertAdjacentHTML('afterend', json.after[key]);
-			});
-		}
-		if('before' in json) {
-			Object.keys(json.before).forEach(key => {
-				document.querySelector(key).insertAdjacentHTML('beforebegin', json.before[key]);
-			});
-		}
-		if('append' in json) {
-			Object.keys(json.append).forEach(key => {
-				document.querySelector(key).insertAdjacentHTML('beforeend', json.append[key]);
-			});
-		}
-		if('prepend' in json) {
-			Object.keys(json.prepend).forEach(key => {
-				document.querySelector(key).insertAdjacentHTML('afterbegin', json.prepend[key]);
-			});
-		}
-		if('addClass' in json) {
-			Object.keys(json.addClass).forEach(selector => {
-				$(selector).forEach(el => {
-					json.addClass[selector].split(',').forEach(cname => {
-						el.classList.add(cname);
-					});
+export default async function handleJSON(json) {
+	if(typeof json === 'string') {
+		json = JSON.parse(json.trim());
+	} else if(typeof json !== 'object') {
+		return false;
+	}
+	if('text' in json) {
+		Object.keys(json.text).forEach(key => {
+			document.querySelector(key).textContent = json.text[key];
+		});
+	}
+	if('html' in json) {
+		Object.keys(json.html).forEach(key => {
+			document.querySelector(key).innerHTML = json.html[key];
+		});
+	}
+	if('after' in json) {
+		Object.keys(json.after).forEach(key => {
+			document.querySelector(key).insertAdjacentHTML('afterend', json.after[key]);
+		});
+	}
+	if('before' in json) {
+		Object.keys(json.before).forEach(key => {
+			document.querySelector(key).insertAdjacentHTML('beforebegin', json.before[key]);
+		});
+	}
+	if('append' in json) {
+		Object.keys(json.append).forEach(key => {
+			document.querySelector(key).insertAdjacentHTML('beforeend', json.append[key]);
+		});
+	}
+	if('prepend' in json) {
+		Object.keys(json.prepend).forEach(key => {
+			document.querySelector(key).insertAdjacentHTML('afterbegin', json.prepend[key]);
+		});
+	}
+	if('addClass' in json) {
+		Object.keys(json.addClass).forEach(selector => {
+			$(selector).forEach(el => {
+				json.addClass[selector].split(',').forEach(cname => {
+					el.classList.add(cname);
 				});
 			});
-		}
-		if('removeClass' in json) {
-			Object.keys(json.removeClass).forEach(selector => {
-				$(selector).forEach(el => {
-					json.removeClass[selector].split(',').forEach(cname => {
-						el.classList.remove(cname);
-					});
+		});
+	}
+	if('removeClass' in json) {
+		Object.keys(json.removeClass).forEach(selector => {
+			$(selector).forEach(el => {
+				json.removeClass[selector].split(',').forEach(cname => {
+					el.classList.remove(cname);
 				});
 			});
-		}
-		if('attributes' in json) {
-			Object.keys(json.attributes).forEach(selector => {
-				$(selector).forEach(el => {
-					Object.keys(json.attributes[selector]).forEach(attribute => {
-						if(typeof json.attributes[selector][attribute] === 'boolean') {
-							(json.attributes[selector][attribute])
-							? el.setAttribute(attribute, '')
-							: el.removeAttribute(attribute);
-						} else {
-							el.setAttribute(attribute, json.attributes[selector][attribute]);
-						}
-					});
-				});
-			});
-		}
-		if('increment' in json) {
-			Object.keys(json.increment).forEach(selector => {
-				let el = document.querySelector(selector);
-				Object.keys(json.increment[selector]).forEach(attribute => {
-					if(attribute in el) {
-						el[attribute] += json.increment[selector][attribute];
+		});
+	}
+	if('attributes' in json) {
+		Object.keys(json.attributes).forEach(selector => {
+			$(selector).forEach(el => {
+				Object.keys(json.attributes[selector]).forEach(attribute => {
+					if(typeof json.attributes[selector][attribute] === 'boolean') {
+						(json.attributes[selector][attribute])
+						? el.setAttribute(attribute, '')
+						: el.removeAttribute(attribute);
 					} else {
-						el.setAttribute(attribute, parseFloat(el.getAttribute(attribute) + json.increment[selector][attribute]));
+						el.setAttribute(attribute, json.attributes[selector][attribute]);
 					}
 				});
 			});
-		}
-		if('stepUp' in json) {
-			Object.keys(json.stepUp).forEach(selector => {
-				$(selector).forEach(el => {
-					el.stepUp(json.stepUp[selector]);
-				});
-			});
-		}
-		if('stepDown' in json) {
-			Object.keys(json.stepDown).forEach(selector => {
-				$(selector).forEach(el => {
-					el.stepDown(json.stepDown[selector]);
-				});
-			});
-		}
-		if('style' in json) {
-			Object.keys(json.style).forEach(sel => {
-				$(sel).forEach(el => {
-					Object.keys(json.style[sel]).forEach(prop => {
-						el.style[prop.camelCase()] = json.style[sel][prop];
-					});
-				});
-			});
-		}
-		if('dataset' in json) {
-			Object.keys(json.dataset).forEach(sel => {
-				$(sel).forEach(el => {
-					Object.keys(json.dataset[sel]).forEach(prop => {
-						el.dataset[prop] = json.dataset[sel][prop];
-					});
-				});
-			});
-		}
-		if('sessionStorage' in json) {
-			Object.keys(json.sessionStorage).forEach(key => {
-				(json.sessionStorage[key] === '')
-				? sessionStorage.removeItem(key)
-				: sessionStorage.setItem(key, json.sessionStorage[key]);
-			});
-		}
-		if('localStorage' in json) {
-			Object.keys(json.localStorage).forEach(key => {
-				(json.localStorage[key] === '')
-				? sessionStorage.removeItem(key)
-				: localStorage.setItem(key, json.localStorage[key]);
-			});
-		}
-		if('script' in json) {
-			eval(json.script);
-		}
-		if('log' in json) {
-			console.log(json.log);
-		}
-		if('table' in json) {
-			('table' in console) ? console.table(json.table) : console.log(json.table);
-		}
-		if('dir' in json) {
-			('dir' in console) ? console.dir(json.dir) : console.log(json.dir);
-		}
-		if('info' in json) {
-			console.info(json.info);
-		}
-		if('warn' in json) {
-			console.log(json.warn);
-		}
-		if('error' in json) {
-			console.error(json.error);
-		}
-		if('scrollTo' in json) {
-			document.querySelectorAll(json.scrollTo.sel).item(json.scrollTo.nth).scrollIntoView();
-		}
-		if('focus' in json) {
-			document.querySelector(json.focus).focus();
-		}
-		if('select' in json) {
-			document.querySelector(json.select).select();
-		}
-		if('reload' in json) {
-			window.location.reload();
-		}
-		if(('clear' in json) && (json.clear in document.forms)) {
-			document.forms[json.clear].reset();
-		}
-		if('open' in json) {
-			let specs = [];
-			if(typeof json.open.specs !== 'object') {
-				json.open.specs = {};
-			}
-			Object.keys(json.open.specs).forEach(spec => {
-				specs.push(`${spec}=${json.open.specs[spec]}`);
-			});
-			window.open(json.open.url, '_blank', specs.join(','), json.open.replace);
-		}
-		if('show' in json) {
-			$(json.show).forEach(el => {
-				el.show();
-			});
-		}
-		if('showModal' in json) {
-			document.querySelector(json.showModal).showModal();
-		}
-		if (('animate' in json) && ('animate' in Element.prototype)) {
-			Object.keys(json.animate).forEach(sel => {
-				try {
-					let els = Array.from(document.querySelectorAll(sel));
-					els.forEach(el => {
-						el.animate(json.animate[sel].keyframes, json.animate[sel].opts);
-					});
-				} catch (err) {
-					console.error(err);
+		});
+	}
+	if('increment' in json) {
+		Object.keys(json.increment).forEach(selector => {
+			let el = document.querySelector(selector);
+			Object.keys(json.increment[selector]).forEach(attribute => {
+				if(attribute in el) {
+					el[attribute] += json.increment[selector][attribute];
+				} else {
+					el.setAttribute(attribute, parseFloat(el.getAttribute(attribute) + json.increment[selector][attribute]));
 				}
 			});
-		}
-		if('close' in json) {
-			$(json.close).forEach(el => {
-				el.close();
+		});
+	}
+	if('stepUp' in json) {
+		Object.keys(json.stepUp).forEach(selector => {
+			$(selector).forEach(el => {
+				el.stepUp(json.stepUp[selector]);
 			});
-		}
-		if ('remove' in json) {
-			$(json.remove).forEach(el => {
-				el.remove();
+		});
+	}
+	if('stepDown' in json) {
+		Object.keys(json.stepDown).forEach(selector => {
+			$(selector).forEach(el => {
+				el.stepDown(json.stepDown[selector]);
 			});
-		}
-		if('triggerEvent' in json) {
-			Object.keys(json.triggerEvent).forEach(selector => {
-				$(selector).forEach(target => {
-					let event = json.triggerEvent[selector].toLowerCase();
-					if(event === 'click') {
-						target.dispatchEvent(new MouseEvent(event));
-					} else {
-						target.dispatchEvent(new Event(event));
-					}
+		});
+	}
+	if('style' in json) {
+		Object.keys(json.style).forEach(sel => {
+			$(sel).forEach(el => {
+				Object.keys(json.style[sel]).forEach(prop => {
+					el.style[prop.camelCase()] = json.style[sel][prop];
 				});
 			});
-		}
-		if('serverEvent' in json) {
-			let serverEvent = new EventSource(json.serverEvent);
-			serverEvent.addEventListener('ping', event => {
-				handleJSON(JSON.parse(event.data));
+		});
+	}
+	if('dataset' in json) {
+		Object.keys(json.dataset).forEach(sel => {
+			$(sel).forEach(el => {
+				Object.keys(json.dataset[sel]).forEach(prop => {
+					el.dataset[prop] = json.dataset[sel][prop];
+				});
 			});
-			serverEvent.addEventListener('close', event => {
-				serverEvent.close();
-				handleJSON(JSON.parse(event.data));
-			});
-			serverEvent.addEventListener('error', error => {
-				console.error(new Error(error));
-				console.error(error);
-			});
+		});
+	}
+	if('sessionStorage' in json) {
+		Object.keys(json.sessionStorage).forEach(key => {
+			(json.sessionStorage[key] === '')
+			? sessionStorage.removeItem(key)
+			: sessionStorage.setItem(key, json.sessionStorage[key]);
+		});
+	}
+	if('localStorage' in json) {
+		Object.keys(json.localStorage).forEach(key => {
+			(json.localStorage[key] === '')
+			? sessionStorage.removeItem(key)
+			: localStorage.setItem(key, json.localStorage[key]);
+		});
+	}
+	if('script' in json) {
+		eval(json.script);
+	}
+	if('log' in json) {
+		console.log(json.log);
+	}
+	if('table' in json) {
+		('table' in console) ? console.table(json.table) : console.log(json.table);
+	}
+	if('dir' in json) {
+		('dir' in console) ? console.dir(json.dir) : console.log(json.dir);
+	}
+	if('info' in json) {
+		console.info(json.info);
+	}
+	if('warn' in json) {
+		console.log(json.warn);
+	}
+	if('error' in json) {
+		console.error(json.error);
+	}
+	if('scrollTo' in json) {
+		document.querySelectorAll(json.scrollTo.sel).item(json.scrollTo.nth).scrollIntoView();
+	}
+	if('focus' in json) {
+		document.querySelector(json.focus).focus();
+	}
+	if('select' in json) {
+		document.querySelector(json.select).select();
+	}
+	if('reload' in json) {
+		window.location.reload();
+	}
+	if(('clear' in json) && (json.clear in document.forms)) {
+		document.forms[json.clear].reset();
+	}
+	if('open' in json) {
+		let specs = [];
+		if(typeof json.open.specs !== 'object') {
+			json.open.specs = {};
 		}
-		if ('notify' in json) {
-			notify(json.notify);
-		}
-		return json;
-	});
+		Object.keys(json.open.specs).forEach(spec => {
+			specs.push(`${spec}=${json.open.specs[spec]}`);
+		});
+		window.open(json.open.url, '_blank', specs.join(','), json.open.replace);
+	}
+	if('show' in json) {
+		$(json.show).forEach(el => {
+			el.show();
+		});
+	}
+	if('showModal' in json) {
+		document.querySelector(json.showModal).showModal();
+	}
+	if (('animate' in json) && ('animate' in Element.prototype)) {
+		Object.keys(json.animate).forEach(sel => {
+			try {
+				let els = Array.from(document.querySelectorAll(sel));
+				els.forEach(el => {
+					el.animate(json.animate[sel].keyframes, json.animate[sel].opts);
+				});
+			} catch (err) {
+				console.error(err);
+			}
+		});
+	}
+	if('close' in json) {
+		$(json.close).forEach(el => {
+			el.close();
+		});
+	}
+	if ('remove' in json) {
+		$(json.remove).forEach(el => {
+			el.remove();
+		});
+	}
+	if('triggerEvent' in json) {
+		Object.keys(json.triggerEvent).forEach(selector => {
+			$(selector).forEach(target => {
+				let event = json.triggerEvent[selector].toLowerCase();
+				if(event === 'click') {
+					target.dispatchEvent(new MouseEvent(event));
+				} else {
+					target.dispatchEvent(new Event(event));
+				}
+			});
+		});
+	}
+	if('serverEvent' in json) {
+		let serverEvent = new EventSource(json.serverEvent);
+		serverEvent.addEventListener('ping', event => {
+			handleJSON(JSON.parse(event.data));
+		});
+		serverEvent.addEventListener('close', event => {
+			serverEvent.close();
+			handleJSON(JSON.parse(event.data));
+		});
+		serverEvent.addEventListener('error', error => {
+			console.error(new Error(error));
+			console.error(error);
+		});
+	}
+	if ('notify' in json) {
+		notify(json.notify);
+	}
+	return json;
 }

--- a/json_response.js
+++ b/json_response.js
@@ -1,235 +1,238 @@
 import {notify, query as $} from './functions.js';
 
 export default function handleJSON(json) {
-	if(typeof json === 'string') {
-		json = JSON.parse(json.trim());
-	} else if(typeof json !== 'object') {
-		return false;
-	}
-	if('text' in json) {
-		Object.keys(json.text).forEach(key => {
-			document.querySelector(key).textContent = json.text[key];
-		});
-	}
-	if('html' in json) {
-		Object.keys(json.html).forEach(key => {
-			document.querySelector(key).innerHTML = json.html[key];
-		});
-	}
-	if('after' in json) {
-		Object.keys(json.after).forEach(key => {
-			document.querySelector(key).insertAdjacentHTML('afterend', json.after[key]);
-		});
-	}
-	if('before' in json) {
-		Object.keys(json.before).forEach(key => {
-			document.querySelector(key).insertAdjacentHTML('beforebegin', json.before[key]);
-		});
-	}
-	if('append' in json) {
-		Object.keys(json.append).forEach(key => {
-			document.querySelector(key).insertAdjacentHTML('beforeend', json.append[key]);
-		});
-	}
-	if('prepend' in json) {
-		Object.keys(json.prepend).forEach(key => {
-			document.querySelector(key).insertAdjacentHTML('afterbegin', json.prepend[key]);
-		});
-	}
-	if('addClass' in json) {
-		Object.keys(json.addClass).forEach(selector => {
-			$(selector).forEach(el => {
-				json.addClass[selector].split(',').forEach(cname => {
-					el.classList.add(cname);
+	return Promise.resolve().then(() => {
+		if(typeof json === 'string') {
+			json = JSON.parse(json.trim());
+		} else if(typeof json !== 'object') {
+			return false;
+		}
+		if('text' in json) {
+			Object.keys(json.text).forEach(key => {
+				document.querySelector(key).textContent = json.text[key];
+			});
+		}
+		if('html' in json) {
+			Object.keys(json.html).forEach(key => {
+				document.querySelector(key).innerHTML = json.html[key];
+			});
+		}
+		if('after' in json) {
+			Object.keys(json.after).forEach(key => {
+				document.querySelector(key).insertAdjacentHTML('afterend', json.after[key]);
+			});
+		}
+		if('before' in json) {
+			Object.keys(json.before).forEach(key => {
+				document.querySelector(key).insertAdjacentHTML('beforebegin', json.before[key]);
+			});
+		}
+		if('append' in json) {
+			Object.keys(json.append).forEach(key => {
+				document.querySelector(key).insertAdjacentHTML('beforeend', json.append[key]);
+			});
+		}
+		if('prepend' in json) {
+			Object.keys(json.prepend).forEach(key => {
+				document.querySelector(key).insertAdjacentHTML('afterbegin', json.prepend[key]);
+			});
+		}
+		if('addClass' in json) {
+			Object.keys(json.addClass).forEach(selector => {
+				$(selector).forEach(el => {
+					json.addClass[selector].split(',').forEach(cname => {
+						el.classList.add(cname);
+					});
 				});
 			});
-		});
-	}
-	if('removeClass' in json) {
-		Object.keys(json.removeClass).forEach(selector => {
-			$(selector).forEach(el => {
-				json.removeClass[selector].split(',').forEach(cname => {
-					el.classList.remove(cname);
+		}
+		if('removeClass' in json) {
+			Object.keys(json.removeClass).forEach(selector => {
+				$(selector).forEach(el => {
+					json.removeClass[selector].split(',').forEach(cname => {
+						el.classList.remove(cname);
+					});
 				});
 			});
-		});
-	}
-	if('attributes' in json) {
-		Object.keys(json.attributes).forEach(selector => {
-			$(selector).forEach(el => {
-				Object.keys(json.attributes[selector]).forEach(attribute => {
-					if(typeof json.attributes[selector][attribute] === 'boolean') {
-						(json.attributes[selector][attribute])
+		}
+		if('attributes' in json) {
+			Object.keys(json.attributes).forEach(selector => {
+				$(selector).forEach(el => {
+					Object.keys(json.attributes[selector]).forEach(attribute => {
+						if(typeof json.attributes[selector][attribute] === 'boolean') {
+							(json.attributes[selector][attribute])
 							? el.setAttribute(attribute, '')
 							: el.removeAttribute(attribute);
+						} else {
+							el.setAttribute(attribute, json.attributes[selector][attribute]);
+						}
+					});
+				});
+			});
+		}
+		if('increment' in json) {
+			Object.keys(json.increment).forEach(selector => {
+				let el = document.querySelector(selector);
+				Object.keys(json.increment[selector]).forEach(attribute => {
+					if(attribute in el) {
+						el[attribute] += json.increment[selector][attribute];
 					} else {
-						el.setAttribute(attribute, json.attributes[selector][attribute]);
+						el.setAttribute(attribute, parseFloat(el.getAttribute(attribute) + json.increment[selector][attribute]));
 					}
 				});
 			});
-		});
-	}
-	if('increment' in json) {
-		Object.keys(json.increment).forEach(selector => {
-			let el = document.querySelector(selector);
-			Object.keys(json.increment[selector]).forEach(attribute => {
-				if(attribute in el) {
-					el[attribute] += json.increment[selector][attribute];
-				} else {
-					el.setAttribute(attribute, parseFloat(el.getAttribute(attribute) + json.increment[selector][attribute]));
-				}
-			});
-		});
-	}
-	if('stepUp' in json) {
-		Object.keys(json.stepUp).forEach(selector => {
-			$(selector).forEach(el => {
-				el.stepUp(json.stepUp[selector]);
-			});
-		});
-	}
-	if('stepDown' in json) {
-		Object.keys(json.stepDown).forEach(selector => {
-			$(selector).forEach(el => {
-				el.stepDown(json.stepDown[selector]);
-			});
-		});
-	}
-	if('style' in json) {
-		Object.keys(json.style).forEach(sel => {
-			$(sel).forEach(el => {
-				Object.keys(json.style[sel]).forEach(prop => {
-					el.style[prop.camelCase()] = json.style[sel][prop];
+		}
+		if('stepUp' in json) {
+			Object.keys(json.stepUp).forEach(selector => {
+				$(selector).forEach(el => {
+					el.stepUp(json.stepUp[selector]);
 				});
 			});
-		});
-	}
-	if('dataset' in json) {
-		Object.keys(json.dataset).forEach(sel => {
-			$(sel).forEach(el => {
-				Object.keys(json.dataset[sel]).forEach(prop => {
-					el.dataset[prop] = json.dataset[sel][prop];
+		}
+		if('stepDown' in json) {
+			Object.keys(json.stepDown).forEach(selector => {
+				$(selector).forEach(el => {
+					el.stepDown(json.stepDown[selector]);
 				});
 			});
-		});
-	}
-	if('sessionStorage' in json) {
-		Object.keys(json.sessionStorage).forEach(key => {
-			(json.sessionStorage[key] === '')
+		}
+		if('style' in json) {
+			Object.keys(json.style).forEach(sel => {
+				$(sel).forEach(el => {
+					Object.keys(json.style[sel]).forEach(prop => {
+						el.style[prop.camelCase()] = json.style[sel][prop];
+					});
+				});
+			});
+		}
+		if('dataset' in json) {
+			Object.keys(json.dataset).forEach(sel => {
+				$(sel).forEach(el => {
+					Object.keys(json.dataset[sel]).forEach(prop => {
+						el.dataset[prop] = json.dataset[sel][prop];
+					});
+				});
+			});
+		}
+		if('sessionStorage' in json) {
+			Object.keys(json.sessionStorage).forEach(key => {
+				(json.sessionStorage[key] === '')
 				? sessionStorage.removeItem(key)
 				: sessionStorage.setItem(key, json.sessionStorage[key]);
-		});
-	}
-	if('localStorage' in json) {
-		Object.keys(json.localStorage).forEach(key => {
-			(json.localStorage[key] === '')
+			});
+		}
+		if('localStorage' in json) {
+			Object.keys(json.localStorage).forEach(key => {
+				(json.localStorage[key] === '')
 				? sessionStorage.removeItem(key)
 				: localStorage.setItem(key, json.localStorage[key]);
-		});
-	}
-	if('script' in json) {
-		eval(json.script);
-	}
-	if('log' in json) {
-		console.log(json.log);
-	}
-	if('table' in json) {
-		('table' in console) ? console.table(json.table) : console.log(json.table);
-	}
-	if('dir' in json) {
-		('dir' in console) ? console.dir(json.dir) : console.log(json.dir);
-	}
-	if('info' in json) {
-		console.info(json.info);
-	}
-	if('warn' in json) {
-		console.log(json.warn);
-	}
-	if('error' in json) {
-		console.error(json.error);
-	}
-	if('scrollTo' in json) {
-		document.querySelectorAll(json.scrollTo.sel).item(json.scrollTo.nth).scrollIntoView();
-	}
-	if('focus' in json) {
-		document.querySelector(json.focus).focus();
-	}
-	if('select' in json) {
-		document.querySelector(json.select).select();
-	}
-	if('reload' in json) {
-		window.location.reload();
-	}
-	if(('clear' in json) && (json.clear in document.forms)) {
-		document.forms[json.clear].reset();
-	}
-	if('open' in json) {
-		let specs = [];
-		if(typeof json.open.specs !== 'object') {
-			json.open.specs = {};
+			});
 		}
-		Object.keys(json.open.specs).forEach(spec => {
-			specs.push(`${spec}=${json.open.specs[spec]}`);
-		});
-		window.open(json.open.url, '_blank', specs.join(','), json.open.replace);
-	}
-	if('show' in json) {
-		$(json.show).forEach(el => {
-			el.show();
-		});
-	}
-	if('showModal' in json) {
-		document.querySelector(json.showModal).showModal();
-	}
-	if (('animate' in json) && ('animate' in Element.prototype)) {
-		Object.keys(json.animate).forEach(sel => {
-			try {
-				let els = Array.from(document.querySelectorAll(sel));
-				els.forEach(el => {
-					el.animate(json.animate[sel].keyframes, json.animate[sel].opts);
-				});
-			} catch (err) {
-				console.error(err);
+		if('script' in json) {
+			eval(json.script);
+		}
+		if('log' in json) {
+			console.log(json.log);
+		}
+		if('table' in json) {
+			('table' in console) ? console.table(json.table) : console.log(json.table);
+		}
+		if('dir' in json) {
+			('dir' in console) ? console.dir(json.dir) : console.log(json.dir);
+		}
+		if('info' in json) {
+			console.info(json.info);
+		}
+		if('warn' in json) {
+			console.log(json.warn);
+		}
+		if('error' in json) {
+			console.error(json.error);
+		}
+		if('scrollTo' in json) {
+			document.querySelectorAll(json.scrollTo.sel).item(json.scrollTo.nth).scrollIntoView();
+		}
+		if('focus' in json) {
+			document.querySelector(json.focus).focus();
+		}
+		if('select' in json) {
+			document.querySelector(json.select).select();
+		}
+		if('reload' in json) {
+			window.location.reload();
+		}
+		if(('clear' in json) && (json.clear in document.forms)) {
+			document.forms[json.clear].reset();
+		}
+		if('open' in json) {
+			let specs = [];
+			if(typeof json.open.specs !== 'object') {
+				json.open.specs = {};
 			}
-		});
-	}
-	if('close' in json) {
-		$(json.close).forEach(el => {
-			el.close();
-		});
-	}
-	if ('remove' in json) {
-		$(json.remove).forEach(el => {
-			el.remove();
-		});
-	}
-	if('triggerEvent' in json) {
-		Object.keys(json.triggerEvent).forEach(selector => {
-			$(selector).forEach(target => {
-				let event = json.triggerEvent[selector].toLowerCase();
-				if(event === 'click') {
-					target.dispatchEvent(new MouseEvent(event));
-				} else {
-					target.dispatchEvent(new Event(event));
+			Object.keys(json.open.specs).forEach(spec => {
+				specs.push(`${spec}=${json.open.specs[spec]}`);
+			});
+			window.open(json.open.url, '_blank', specs.join(','), json.open.replace);
+		}
+		if('show' in json) {
+			$(json.show).forEach(el => {
+				el.show();
+			});
+		}
+		if('showModal' in json) {
+			document.querySelector(json.showModal).showModal();
+		}
+		if (('animate' in json) && ('animate' in Element.prototype)) {
+			Object.keys(json.animate).forEach(sel => {
+				try {
+					let els = Array.from(document.querySelectorAll(sel));
+					els.forEach(el => {
+						el.animate(json.animate[sel].keyframes, json.animate[sel].opts);
+					});
+				} catch (err) {
+					console.error(err);
 				}
 			});
-		});
-	}
-	if('serverEvent' in json) {
-		let serverEvent = new EventSource(json.serverEvent);
-		serverEvent.addEventListener('ping', event => {
-			handleJSON(JSON.parse(event.data));
-		});
-		serverEvent.addEventListener('close', event => {
-			serverEvent.close();
-			handleJSON(JSON.parse(event.data));
-		});
-		serverEvent.addEventListener('error', error => {
-			console.error(new Error(error));
-			console.error(error);
-		});
-	}
-	if ('notify' in json) {
-		notify(json.notify);
-	}
+		}
+		if('close' in json) {
+			$(json.close).forEach(el => {
+				el.close();
+			});
+		}
+		if ('remove' in json) {
+			$(json.remove).forEach(el => {
+				el.remove();
+			});
+		}
+		if('triggerEvent' in json) {
+			Object.keys(json.triggerEvent).forEach(selector => {
+				$(selector).forEach(target => {
+					let event = json.triggerEvent[selector].toLowerCase();
+					if(event === 'click') {
+						target.dispatchEvent(new MouseEvent(event));
+					} else {
+						target.dispatchEvent(new Event(event));
+					}
+				});
+			});
+		}
+		if('serverEvent' in json) {
+			let serverEvent = new EventSource(json.serverEvent);
+			serverEvent.addEventListener('ping', event => {
+				handleJSON(JSON.parse(event.data));
+			});
+			serverEvent.addEventListener('close', event => {
+				serverEvent.close();
+				handleJSON(JSON.parse(event.data));
+			});
+			serverEvent.addEventListener('error', error => {
+				console.error(new Error(error));
+				console.error(error);
+			});
+		}
+		if ('notify' in json) {
+			notify(json.notify);
+		}
+		return json;
+	});
 }

--- a/test/index.html
+++ b/test/index.html
@@ -38,67 +38,67 @@
 		<dialog id="contact-dialog">
 			<header>
 				<button type="reset" form="contact-form" data-close="#contact-dialog">X</button>
-				<form name="contact-form" id="contact-form">
-					<fieldset>
-						<legend>Basic Info</legend>
-						<input type="text" name="basic[first]" autocomplete="given-name" placeholder="First name" pattern="[A-z]+" required="" />
-						<input type="text" name="basic[middle]" autocomplete="additional-name" placeholder="Middle name" pattern="[A-z]+" />
-						<input type="text" name="basic[last]" autocomplete="family-name" placeholder="Last Name" Pattern="[A-z]+" required="" />
-						<br />
-						<label>Organization <input type="text" name="basic[org]" autocomplete="organization" placeholder="Company" /></label>
-						<br />
-						<label>Birthday<input type="date" name="basic[bday]" autocomplete="bday" placeholder="YYYY-mm-dd" required="" /></label>
-						<br />
-						<label for="sex">Sex</label>
-						<select name="basic[sex]" id="sex" autocomplete="sex" required="">
-							<option value="">Pick one</option>
-							<option value="Male">Male</option>
-							<option value="Female">Female</option>
-						</select>
-					</fieldset>
-					<fieldset>
-						<legend>Address</legend>
-						<input type="text" name="address[street]" autocomplete="street-address" placeholder="123 Some Street" pattern="\d+ [\w\.# ]+" required=""/>
-						<br />
-						<input type="text" name="address[city]" autocomplete="address-level2" placeholder="City" pattern="[A-z ]+" required=""/>
-						<span>, </span>
-						<input type="text" name="address[state]" autocomplete="address-level1" placeholder="State" pattern="[A-z ]+" required="" />
-						<br />
-						<input type="number" name="address[postal]" autocomplete="postal-code" placeholder="#####" min="10000" max="99999" required="" />
-						<br />
-					</fieldset>
-					<fieldset>
-						<legend>Contact Info</legend>
-						<input type="email" name="contact[email]" autocomplete="email" placeholder="user@example.com" required="" />
-						<br />
-						<input type="tel" name="contact[tel]" autocomplete="tel" placeholder="+1-123-456-7890" required="" />
-						<br />
-						<input type="url" name="contact[url]" autocomplete="url" placeholder="http://example.com" />
-					</fieldset>
-					<fieldset>
-						<legend>Credentials</legend>
-						<input type="text" name="creds[user]" autocomplete="username" placeholder="username" required="" />
-						<br />
-						<input type="password" name="creds[password]" autocomplete="new-password" placeholder="***********" required="" />
-					</fieldset>
-					<fieldset>
-						<legend>Payment Info</legend>
-						<select name="cc[type]" required="">
-							<option value="">Select Credit Card Type</option>
-							<option>Master Card</option>
-							<option>Visa</option>
-						</select>
-						<br />
-						<input type="number" autocomplete="cc-number" min="1000000000000" max="9999999999999" placeholder="Credit Card Number (no '-')" required="" />
-						<br />
-						<input type="date" name="cc[exp]" autocomplete="cc-exp" placeholder="YYYY-MM-DD" required="" />
-						<br />
-						<input type="number" autocomplete="cc-csc" min="100" max="9999" name="cc[csc]" placeholder="CSC (###)" required="" />
-					</fieldset>
-					<button type="submit">Submit</button>
-					<button type="reset">Reset</button>
-				</form>
 			</header>
+			<form name="contact-form" id="contact-form">
+				<fieldset>
+					<legend>Basic Info</legend>
+					<input type="text" name="basic[first]" autocomplete="given-name" placeholder="First name" pattern="[A-z]+" required="" />
+					<input type="text" name="basic[middle]" autocomplete="additional-name" placeholder="Middle name" pattern="[A-z]+" />
+					<input type="text" name="basic[last]" autocomplete="family-name" placeholder="Last Name" Pattern="[A-z]+" required="" />
+					<br />
+					<label>Organization <input type="text" name="basic[org]" autocomplete="organization" placeholder="Company" /></label>
+					<br />
+					<label>Birthday<input type="date" name="basic[bday]" autocomplete="bday" placeholder="YYYY-mm-dd" required="" /></label>
+					<br />
+					<label for="sex">Sex</label>
+					<select name="basic[sex]" id="sex" autocomplete="sex" required="">
+						<option value="">Pick one</option>
+						<option value="Male">Male</option>
+						<option value="Female">Female</option>
+					</select>
+				</fieldset>
+				<fieldset>
+					<legend>Address</legend>
+					<input type="text" name="address[street]" autocomplete="street-address" placeholder="123 Some Street" pattern="\d+ [\w\.# ]+" required=""/>
+					<br />
+					<input type="text" name="address[city]" autocomplete="address-level2" placeholder="City" pattern="[A-z ]+" required=""/>
+					<span>, </span>
+					<input type="text" name="address[state]" autocomplete="address-level1" placeholder="State" pattern="[A-z ]+" required="" />
+					<br />
+					<input type="number" name="address[postal]" autocomplete="postal-code" placeholder="#####" min="10000" max="99999" required="" />
+					<br />
+				</fieldset>
+				<fieldset>
+					<legend>Contact Info</legend>
+					<input type="email" name="contact[email]" autocomplete="email" placeholder="user@example.com" required="" />
+					<br />
+					<input type="tel" name="contact[tel]" autocomplete="tel" placeholder="+1-123-456-7890" required="" />
+					<br />
+					<input type="url" name="contact[url]" autocomplete="url" placeholder="http://example.com" />
+				</fieldset>
+				<fieldset>
+					<legend>Credentials</legend>
+					<input type="text" name="creds[user]" autocomplete="username" placeholder="username" required="" />
+					<br />
+					<input type="password" name="creds[password]" autocomplete="new-password" placeholder="***********" required="" />
+				</fieldset>
+				<fieldset>
+					<legend>Payment Info</legend>
+					<select name="cc[type]" required="">
+						<option value="">Select Credit Card Type</option>
+						<option>Master Card</option>
+						<option>Visa</option>
+					</select>
+					<br />
+					<input type="number" autocomplete="cc-number" min="1000000000000" max="9999999999999" placeholder="Credit Card Number (no '-')" required="" />
+					<br />
+					<input type="date" name="cc[exp]" autocomplete="cc-exp" placeholder="YYYY-MM-DD" required="" />
+					<br />
+					<input type="number" autocomplete="cc-csc" min="100" max="9999" name="cc[csc]" placeholder="CSC (###)" required="" />
+				</fieldset>
+				<button type="submit">Submit</button>
+				<button type="reset">Reset</button>
+			</form>
 		</dialog>
 		<dialog id="weather-dialog">
 			<header>

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ import kbdShortcuts from '../kbd_shortcuts.js';
 import {$} from '../functions.js';
 import Cookie from '../Cookie.js';
 
-document.body.classList.replace('no-js', 'js');
+$('body').replaceClass('no-js', 'js');
 
 $(document).ready(loadHandler).keypress(kbdShortcuts);
 /* eslint-disable quotes */

--- a/test/index.js
+++ b/test/index.js
@@ -4,16 +4,17 @@ import kbdShortcuts from '../kbd_shortcuts.js';
 import {$} from '../functions.js';
 import Cookie from '../Cookie.js';
 
-$('body').replaceClass('no-js', 'js');
+(async () => {
+	$('body').replaceClass('no-js', 'js');
+	await $(document).ready(loadHandler).then($doc => $doc.keypress(kbdShortcuts));
 
-$(document).ready(loadHandler).keypress(kbdShortcuts);
-/* eslint-disable quotes */
-Cookie.set('foo', 'bar', {"max-age": 60, path: '/test'});
-Cookie.set('name', 'Chris', {"max-age": 60, path: '/test'});
-Cookie.set('gibberish', '~!@#$%^&*()_+{}|[]\\;:"<>,./?', {"max-age": 60, path: '/test'});
-Cookie.set(Cookie.get('gibberish'), 'Works', {"max-age": 60, path: '/test'});
-if (Cookie.has(Cookie.get('gibberish'))) {
-	Cookie.delete('foo');
-	console.log(Cookie.getAll());
-	console.log(Cookie.get('gibberish'));
-}
+	Cookie.set('foo', 'bar', {'max-age': 60, path: '/test'});
+	Cookie.set('name', 'Chris', {'max-age': 60, path: '/test'});
+	Cookie.set('gibberish', '~!@#$%^&*()_+{}|[]\\;:"<>,./?', {'max-age': 60, path: '/test'});
+	Cookie.set(Cookie.get('gibberish'), 'Works', {'max-age': 60, path: '/test'});
+	if (Cookie.has(Cookie.get('gibberish'))) {
+		Cookie.delete('foo');
+		console.log(Cookie.getAll());
+		console.log(Cookie.get('gibberish'));
+	}
+})();

--- a/zq.js
+++ b/zq.js
@@ -60,23 +60,6 @@ export default class zQ {
 		return this.results[n];
 	}
 
-	has(node) {
-		return [...this].includes(node);
-	}
-
-	each(callback, sync = true) {
-		if (sync) {
-			[...this].forEach(callback);
-			return this;
-		} else {
-			return Promise.resolve().then(() => this.each(callback, true));
-		}
-	}
-
-	// forEach(...args) {
-	// 	return this.each(...args);
-	// }
-
 	*values() {
 		for (let item of this.results) {
 			yield item;
@@ -99,30 +82,49 @@ export default class zQ {
 	[Symbol.iterator]() {
 		return this.values();
 	}
+	
+	async forEach(...args) {
+		return this.each(...args);
+	}
+
+	async has(node) {
+		return [...this].includes(node);
+	}
+
+	async each(callback) {
+		[...this].forEach(callback);
+		return this;
+	}
 
 	/**
 	 * Note: This is for `HTMLDialogElement.prototype.show`, not the inverse
 	 * of `hide`
 	 */
-	show() {
-		this.each(node => {
+	async show() {
+		return this.each(node => {
 			if ('show' in node) {
 				node.show();
 			}
-		}, false);
-		return this;
+		});
 	}
 
-	close() {
-		this.each(node => {
+	async showModal() {
+		return this.each(node => {
+			if ('showModal' in node) {
+				node.showModal();
+			}
+		});
+	}
+
+	async close() {
+		return this.each(node => {
 			if ('close' in node) {
 				node.close();
 			}
-		}, false);
-		return this;
+		});
 	}
 
-	animate(keyframes, opts) {
+	async animate(keyframes, opts) {
 		if ('animate' in Element.prototype) {
 			return this.map(node => node.animate(keyframes, opts));
 		} else {
@@ -130,139 +132,138 @@ export default class zQ {
 		}
 	}
 
-	some(callback) {
+	async some(callback) {
 		return [...this].some(callback);
 	}
 
-	every(callback) {
+	async every(callback) {
 		return [...this].every(callback);
 	}
 
-	find(callback) {
+	async find(callback) {
 		return [...this].find(callback);
 	}
 
-	map(callback) {
+	async map(callback) {
 		return [...this].map(callback);
 	}
 
-	addClass(cname) {
-		this.each(el => el.classList.add(cname), false);
+	async addClass(cname) {
+		this.each(el => el.classList.add(cname));
 		return this;
 	}
 
-	removeClass(cname) {
-		this.each(el => el.classList.remove(cname), false);
+	async removeClass(cname) {
+		this.each(el => el.classList.remove(cname));
 		return this;
 	}
 
-	hasClass(cname) {
+	async hasClass(cname) {
 		return this.some(el => el.classList.contains(cname));
 	}
 
-	toggleClass(cname, force) {
+	async toggleClass(cname, force) {
 		if (typeof force !== 'undefined') {
-			return this.each(node => node.classList.toggle(cname, force), false);
+			return this.each(node => node.classList.toggle(cname, force));
 		} else {
-			return this.each(node => node.classList.toggle(cname), false);
+			return this.each(node => node.classList.toggle(cname));
 		}
 	}
 
-	replaceClass(cname1, cname2) {
-		this.each(node => node.classList.replace(cname1, cname2), false);
+	async replaceClass(cname1, cname2) {
+		this.each(node => node.classList.replace(cname1, cname2));
 		return this;
 	}
 
-	pickClass(cname1, cname2, condition) {
+	async pickClass(cname1, cname2, condition) {
 		this.addClass(condition ? cname1 : cname2);
 		return this;
 	}
 
-	remove() {
-		this.each(el => el.remove(), false);
+	async remove() {
+		this.each(el => el.remove());
 		return this;
 	}
 
-	empty(query = null) {
+	async empty(query = null) {
 		if (typeof query === 'string') {
 			this.each(node => [...node.children].forEach(child => {
 				if (child.matches(query)) {
 					child.remove();
 				}
-			}), false);
+			}));
 		} else {
-			this.each(node => [...node.children].forEach(child => child.remove()), false);
+			this.each(node => [...node.children].forEach(child => child.remove()));
 		}
 		return this;
 	}
 
-	hide(hidden = true, sync = true) {
-		return this.each(el => el.hidden = hidden, sync);
+	async hide(hidden = true) {
+		return this.each(el => el.hidden = hidden);
 	}
 
-	unhide(shown = true, sync = true) {
+	async unhide(shown = true, sync = true) {
 		return this.hide(!shown, sync);
 	}
 
-	append(...nodes) {
-		return this.each(el => el.append(...nodes), false);
+	async append(...nodes) {
+		return this.each(el => el.append(...nodes));
 	}
 
-	prepend(...nodes) {
-		return this.each(el => el.prepend(...nodes), false);
+	async prepend(...nodes) {
+		return this.each(el => el.prepend(...nodes));
 	}
 
-	before(...nodes) {
-		return this.each(el => el.before(...nodes), false);
+	async before(...nodes) {
+		return this.each(el => el.before(...nodes));
 	}
 
-	after(...nodes) {
-		return this.each(el => el.after(...nodes), false);
+	async after(...nodes) {
+		return this.each(el => el.after(...nodes));
 	}
 
-	afterBegin(text) {
-		return this.each(el => el.insertAdjacentHTML('afterbegin', text), false);
+	async afterBegin(text) {
+		return this.each(el => el.insertAdjacentHTML('afterbegin', text));
 	}
 
-	afterEnd(text) {
-		return this.each(el => el.insertAdjacentHTML('afterend', text), false);
+	async afterEnd(text) {
+		return this.each(el => el.insertAdjacentHTML('afterend', text));
 	}
 
-	beforeBegin(text) {
-		return this.each(el => el.insertAdjacentHTML('beforebegin', text), false);
+	async beforeBegin(text) {
+		return this.each(el => el.insertAdjacentHTML('beforebegin', text));
 	}
 
-	beforeEnd(text) {
-		return this.each(el => el.insertAdjacentHTML('beforeend', text), false);
+	async beforeEnd(text) {
+		return this.each(el => el.insertAdjacentHTML('beforeend', text));
 	}
 
-	hasAttribute(attr) {
+	async hasAttribute(attr) {
 		return this.some(el => el.hasAttribute(attr));
 	}
 
-	attr(attr, val) {
+	async attr(attr, val) {
 		if (typeof val == 'undefined' || val === true) {
 			val = '';
 		}
 		if (val === false) {
-			return this.each(el => el.removeAttribute(attr), false);
+			return this.each(el => el.removeAttribute(attr));
 		} else {
-			return this.each(el => el.setAttribute(attr, val), false);
+			return this.each(el => el.setAttribute(attr, val));
 		}
 	}
 
-	pause() {
-		this.each(media => media.pause(), false);
-		return this;
+	async pause() {
+		return this.each(media => media.pause());
 	}
 
 	/*==================== Listener Functions =================================*/
-	on(event, callback, ...args) {
-		this.each(node => node.addEventListener(event, callback, ...args), false);
+	async on(event, callback, ...args) {
+		this.each(node => node.addEventListener(event, callback, ...args));
 		return this;
 	}
 
-	ready(callback, ...args) {
+	async ready(callback, ...args) {
 		this.on('DOMContentLoaded', callback, ...args);
 		if (document.readyState !== 'loading') {
 			this.each(node => {
@@ -272,21 +273,20 @@ export default class zQ {
 		return this;
 	}
 
-	networkChange(callback, ...args) {
+	async networkChange(callback, ...args) {
 		return this.online(callback, ...args).offline(callback, ...args);
 	}
 
-	playing(callback) {
-		this.each(e => e.onplay = callback, false);
-		return this;
+	async playing(callback) {
+		return this.each(e => e.onplay = callback);
 	}
 
-	paused(callback) {
+	async paused(callback) {
 		this.each(e => e.onpause = callback, false);
 		return this;
 	}
 
-	visibilitychange(callback, ...args) {
+	async visibilitychange(callback, ...args) {
 		this.each(e => {
 			PREFIXES.forEach(pre => {
 				e.addEventListener(`${pre}visibilitychange`, callback, ...args);
@@ -295,99 +295,99 @@ export default class zQ {
 		return this;
 	}
 
-	click(callback, ...args) {
+	async click(callback, ...args) {
 		return this.on('click', callback, ...args);
 	}
 
-	dblclick(callback, ...args) {
+	async dblclick(callback, ...args) {
 		this.on('dblclick', callback, ...args);
 	}
 
-	contextmenu(callback, ...args) {
+	async contextmenu(callback, ...args) {
 		return this.on('contextmenu', callback, ...args);
 	}
 
-	keypress(callback, ...args) {
+	async keypress(callback, ...args) {
 		return this.on('keypress', callback, ...args);
 	}
 
-	keyup(callback, ...args) {
+	async keyup(callback, ...args) {
 		return this.on('keyup', callback, ...args);
 	}
 
-	keydown(callback, ...args) {
+	async keydown(callback, ...args) {
 		return this.on('keydown', ...args);
 	}
 
-	mouseenter(callback, ...args) {
+	async mouseenter(callback, ...args) {
 		return this.on('mouseenter', callback, ...args);
 	}
 
-	mouseleave(callback, ...args) {
+	async mouseleave(callback, ...args) {
 		return this.on('mouseleave', callback, ...args);
 	}
 
-	mouseover(callback, ...args) {
+	async mouseover(callback, ...args) {
 		return this.on('mouseover', callback, ...args);
 	}
 
-	mouseout(callback, ...args) {
+	async mouseout(callback, ...args) {
 		return this.on('mouseout', callback, ...args);
 	}
 
-	mousemove(callback, ...args) {
+	async mousemove(callback, ...args) {
 		return this.on('mousemove', callback, ...args);
 	}
 
-	mousedown(callback, ...args) {
+	async mousedown(callback, ...args) {
 		return this.on('mousedown', callback, ...args);
 	}
 
-	mouseup(callback, ...args) {
+	async mouseup(callback, ...args) {
 		return this.on('mouseup', callback, ...args);
 	}
 
-	input(callback, ...args) {
+	async input(callback, ...args) {
 		return this.on('input', callback, ...args);
 	}
 
-	change(callback, ...args) {
+	async change(callback, ...args) {
 		return this.on('change', callback, ...args);
 	}
 
-	submit(callback, ...args) {
+	async submit(callback, ...args) {
 		return this.on('submit', callback, ...args);
 	}
 
-	reset(callback, ...args) {
+	async reset(callback, ...args) {
 		return this.on('reset', callback, ...args);
 	}
 
-	invalid(callback, ...args) {
+	async invalid(callback, ...args) {
 		return this.on('invalid', callback, ...args);
 	}
 
-	select(callback, ...args) {
+	async select(callback, ...args) {
 		return this.on('select', callback, ...args);
 	}
 
-	focus(callback, ...args) {
+	async focus(callback, ...args) {
 		return this.on('focus', callback, ...args);
 	}
 
-	blur(callback, ...args) {
+	async blur(callback, ...args) {
 		return this.on('blur', callback, ...args);
 	}
 
-	resize(callback, ...args) {
+	async resize(callback, ...args) {
 		return this.on('resize', callback, ...args);
 	}
 
-	updateready(callback, ...args) {
+	async updateready(callback, ...args) {
 		return this.on('updateready', ...args);
 	}
 
-	load(callback, ...args) {
+	async load(callback, ...args) {
 		this.on('load', callback, ...args);
 		if (document.readyState === 'complete') {
 			document.dispatchEvent(new Event('load'));
@@ -395,39 +395,39 @@ export default class zQ {
 		return this;
 	}
 
-	unload(callback, ...args) {
+	async unload(callback, ...args) {
 		return this.on('unload', callback, ...args);
 	}
 
-	beforeunload(callback, ...args) {
+	async beforeunload(callback, ...args) {
 		return this.on('beforeunload', callback, ...args);
 	}
 
-	abort(callback, ...args) {
+	async abort(callback, ...args) {
 		return this.on('abort', callback, ...args);
 	}
 
-	error(callback, ...args) {
+	async error(callback, ...args) {
 		return this.on('error', callback, ...args);
 	}
 
-	scroll(callback, ...args) {
+	async scroll(callback, ...args) {
 		return this.on('scroll', ...args);
 	}
 
-	drag(callback, ...args) {
+	async drag(callback, ...args) {
 		return this.on('drag', callback, ...args);
 	}
 
-	offline(callback, ...args) {
+	async offline(callback, ...args) {
 		return this.on('offline', callback, ...args);
 	}
 
-	online(callback, ...args) {
+	async online(callback, ...args) {
 		return this.on('online', callback, ...args);
 	}
 
-	hashchange(callback, ...args) {
+	async hashchange(callback, ...args) {
 		return this.on('hashchange', callback, ...args);
 	}
 
@@ -435,15 +435,15 @@ export default class zQ {
 		return this.on('visibilitychange', callback);
 	}*/
 
-	popstate(callback, ...args) {
+	async popstate(callback, ...args) {
 		return this.on('popstate', callback, ...args);
 	}
 
-	pagehide(callback, ...args) {
+	async pagehide(callback, ...args) {
 		return this.on('pagehide', callback, ...args);
 	}
 
-	watch(watching, options = [], attributeFilter = []) {
+	async watch(watching, options = [], attributeFilter = []) {
 		/*https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver*/
 		const watcher = new MutationObserver(mutations => {
 			mutations.forEach(mutation => watching[mutation.type].call(mutation));
@@ -452,17 +452,15 @@ export default class zQ {
 			watch[event] = true;
 			return watch;
 		}, {attributeFilter});
-		this.each(el => watcher.observe(el, obs), false);
-		return this;
+		return this.each(el => watcher.observe(el, obs));
 	}
 
 	/**
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver
 	 */
-	intersect(callback, options = {}) {
+	async intersect(callback, options = {}) {
 		const observer = new IntersectionObserver(callback, options);
-		this.each(node => observer.observe(node), false);
-		return this;
+		return this.each(node => observer.observe(node));
 	}
 
 	/*========================================================================*/

--- a/zq.js
+++ b/zq.js
@@ -41,7 +41,7 @@ export default class zQ {
 	}
 
 	set text(str) {
-		this.each(node => node.textContent = str);
+		this.each(node => node.textContent = str, true);
 	}
 
 	get html() {
@@ -49,7 +49,7 @@ export default class zQ {
 	}
 
 	set html(html) {
-		this.each(node => node.innerHTML = html);
+		this.each(node => node.innerHTML = html, false);
 	}
 
 	toString() {
@@ -134,12 +134,8 @@ export default class zQ {
 		return [...this].some(callback);
 	}
 
-	every(callback, sync = true) {
-		if (sync) {
-			return [...this].every(callback);
-		} else {
-			Promise.resolve().then(() => this.every(callback, false));
-		}
+	every(callback) {
+		return [...this].every(callback);
 	}
 
 	find(callback) {
@@ -151,12 +147,12 @@ export default class zQ {
 	}
 
 	addClass(cname) {
-		this.each(el => el.classList.add(cname));
+		this.each(el => el.classList.add(cname), false);
 		return this;
 	}
 
 	removeClass(cname) {
-		this.each(el => el.classList.remove(cname));
+		this.each(el => el.classList.remove(cname), false);
 		return this;
 	}
 
@@ -166,15 +162,14 @@ export default class zQ {
 
 	toggleClass(cname, force) {
 		if (typeof force !== 'undefined') {
-			this.each(node => node.classList.toggle(cname, force));
+			return this.each(node => node.classList.toggle(cname, force), false);
 		} else {
-			this.each(node => node.classList.toggle(cname));
+			return this.each(node => node.classList.toggle(cname), false);
 		}
-		return this;
 	}
 
 	replaceClass(cname1, cname2) {
-		this.each(node => node.classList.replace(cname1, cname2));
+		this.each(node => node.classList.replace(cname1, cname2), false);
 		return this;
 	}
 
@@ -183,8 +178,8 @@ export default class zQ {
 		return this;
 	}
 
-	remove(sync = true) {
-		this.each(el => el.remove(), sync);
+	remove() {
+		this.each(el => el.remove(), false);
 		return this;
 	}
 
@@ -194,9 +189,9 @@ export default class zQ {
 				if (child.matches(query)) {
 					child.remove();
 				}
-			}));
+			}), false);
 		} else {
-			this.each(node => [...node.children].forEach(child => child.remove()));
+			this.each(node => [...node.children].forEach(child => child.remove()), false);
 		}
 		return this;
 	}
@@ -272,7 +267,7 @@ export default class zQ {
 		if (document.readyState !== 'loading') {
 			this.each(node => {
 				callback.bind(node)(new Event('DOMContentLoaded'));
-			});
+			}, false);
 		}
 		return this;
 	}
@@ -282,12 +277,12 @@ export default class zQ {
 	}
 
 	playing(callback) {
-		this.each(e => e.onplay = callback);
+		this.each(e => e.onplay = callback, false);
 		return this;
 	}
 
 	paused(callback) {
-		this.each(e => e.onpause = callback);
+		this.each(e => e.onpause = callback, false);
 		return this;
 	}
 
@@ -296,7 +291,7 @@ export default class zQ {
 			PREFIXES.forEach(pre => {
 				e.addEventListener(`${pre}visibilitychange`, callback, ...args);
 			});
-		});
+		}, false);
 		return this;
 	}
 

--- a/zq.js
+++ b/zq.js
@@ -64,14 +64,18 @@ export default class zQ {
 		return [...this].includes(node);
 	}
 
-	each(...args) {
-		this.results.forEach(...args);
-		return this;
+	each(callback, sync = true) {
+		if (sync) {
+			[...this].forEach(callback);
+			return this;
+		} else {
+			return Promise.resolve().then(() => this.each(callback, true));
+		}
 	}
 
-	forEach(...args) {
-		return this.each(...args);
-	}
+	// forEach(...args) {
+	// 	return this.each(...args);
+	// }
 
 	*values() {
 		for (let item of this.results) {
@@ -105,7 +109,7 @@ export default class zQ {
 			if ('show' in node) {
 				node.show();
 			}
-		});
+		}, false);
 		return this;
 	}
 
@@ -114,7 +118,7 @@ export default class zQ {
 			if ('close' in node) {
 				node.close();
 			}
-		});
+		}, false);
 		return this;
 	}
 
@@ -130,8 +134,12 @@ export default class zQ {
 		return [...this].some(callback);
 	}
 
-	every(callback) {
-		return [...this].every(callback);
+	every(callback, sync = true) {
+		if (sync) {
+			return [...this].every(callback);
+		} else {
+			Promise.resolve().then(() => this.every(callback, false));
+		}
 	}
 
 	find(callback) {
@@ -175,8 +183,8 @@ export default class zQ {
 		return this;
 	}
 
-	remove() {
-		this.each(el => el.remove());
+	remove(sync = true) {
+		this.each(el => el.remove(), sync);
 		return this;
 	}
 
@@ -193,50 +201,44 @@ export default class zQ {
 		return this;
 	}
 
-	hide(hidden = true) {
-		this.each(el => el.hidden = hidden);
-		return this;
+	hide(hidden = true, sync = true) {
+		return this.each(el => el.hidden = hidden, sync);
 	}
 
-	unhide(shown = true) {
-		return this.hide(!shown);
+	unhide(shown = true, sync = true) {
+		return this.hide(!shown, sync);
 	}
 
 	append(...nodes) {
-		this.each(el => el.append(...nodes));
-		return this;
+		return this.each(el => el.append(...nodes), false);
 	}
 
 	prepend(...nodes) {
-		this.each(el => el.prepend(...nodes));
+		return this.each(el => el.prepend(...nodes), false);
 	}
 
 	before(...nodes) {
-		this.each(el => el.before(...nodes));
+		return this.each(el => el.before(...nodes), false);
 	}
 
 	after(...nodes) {
-		this.each(el => el.after(...nodes));
+		return this.each(el => el.after(...nodes), false);
 	}
 
 	afterBegin(text) {
-		this.each(el => el.insertAdjacentHTML('afterbegin', text));
-		return this;
+		return this.each(el => el.insertAdjacentHTML('afterbegin', text), false);
 	}
 
 	afterEnd(text) {
-		this.each(el => el.insertAdjacentHTML('afterend', text));
-		return this;
+		return this.each(el => el.insertAdjacentHTML('afterend', text), false);
 	}
 
 	beforeBegin(text) {
-		this.each(el => el.insertAdjacentHTML('beforebegin', text));
-		return this;
+		return this.each(el => el.insertAdjacentHTML('beforebegin', text), false);
 	}
 
 	beforeEnd(text) {
-		this.each(el => el.insertAdjacentHTML('beforeend', text));
-		return this;
+		return this.each(el => el.insertAdjacentHTML('beforeend', text), false);
 	}
 
 	hasAttribute(attr) {
@@ -248,21 +250,20 @@ export default class zQ {
 			val = '';
 		}
 		if (val === false) {
-			this.each(el => el.removeAttribute(attr));
+			return this.each(el => el.removeAttribute(attr), false);
 		} else {
-			this.each(el => el.setAttribute(attr, val));
+			return this.each(el => el.setAttribute(attr, val), false);
 		}
-		return this;
 	}
 
 	pause() {
-		this.each(media => media.pause());
+		this.each(media => media.pause(), false);
 		return this;
 	}
 
 	/*==================== Listener Functions =================================*/
 	on(event, callback, ...args) {
-		this.each(node => node.addEventListener(event, callback, ...args));
+		this.each(node => node.addEventListener(event, callback, ...args), false);
 		return this;
 	}
 
@@ -456,7 +457,7 @@ export default class zQ {
 			watch[event] = true;
 			return watch;
 		}, {attributeFilter});
-		this.each(el => watcher.observe(el, obs));
+		this.each(el => watcher.observe(el, obs), false);
 		return this;
 	}
 
@@ -465,7 +466,7 @@ export default class zQ {
 	 */
 	intersect(callback, options = {}) {
 		const observer = new IntersectionObserver(callback, options);
-		this.each(node => observer.observe(node));
+		this.each(node => observer.observe(node), false);
 		return this;
 	}
 


### PR DESCRIPTION
## Allow DOM operations to be async. Resolves #59 

### List of significant changes made
- `zQ.prototype.each` now takes an optional `sync` argument
- If `sync` is false, return a `Promise.resolve()`
- For all DOM opreations making use of the `...rest` operator, default
to async
- All event listeners are added async, returning `this`
- `json_response` now uses async
- Update `README.md`

