### PR TITLE
Add async functions for prompt, confirm, and alert

### DIFF
--- a/asyncPrompts.js
+++ b/asyncPrompts.js
@@ -1,0 +1,99 @@
+export async function alert(text) {
+	return await new Promise(resolve => {
+		const dialog = document.createElement('dialog');
+		const msg = document.createElement('div');
+		const close = document.createElement('button');
+
+		dialog.classList.add('clearfix', 'animation-speed-normal', 'animation-ease-in', 'fadeInUp');
+		close.classList.add('float-right');
+		msg.textContent = text;
+		close.textContent = 'Ok';
+
+		dialog.addEventListener('close', event => {
+			event.target.remove();
+			resolve();
+		});
+		close.addEventListener('click', event => event.target.closest('dialog[open]').close());
+		dialog.append(msg, close);
+		document.body.append(dialog);
+		dialog.showModal();
+	});
+}
+
+export async function confirm(text) {
+	return await new Promise(resolve => {
+		const dialog = document.createElement('dialog');
+		const msg = document.createElement('div');
+		const close = document.createElement('button');
+		const ok = document.createElement('button');
+
+		close.type = 'button';
+		ok.type = 'button';
+
+		dialog.classList.add('animation-speed-normal', 'animation-ease-in', 'fadeInUp');
+
+		msg.textContent = text;
+		close.textContent = 'Cancel';
+		ok.textContent = 'Ok';
+
+		dialog.addEventListener('close', event => event.target.remove());
+		close.addEventListener('click', event => {
+			event.target.closest('dialog[open]').close();
+			resolve(false);
+		});
+		ok.addEventListener('click', event => {
+			event.target.closest('dialog[open]').close();
+			resolve(true);
+		});
+		dialog.append(msg, ok, close);
+		document.body.append(dialog);
+		dialog.showModal();
+	});
+}
+
+export async function prompt(text, defaultValue = '') {
+	return await new Promise(resolve => {
+		const dialog = document.createElement('dialog');
+		const msg = document.createElement('div');
+		const close = document.createElement('button');
+		const ok = document.createElement('button');
+		const form = document.createElement('form');
+		const input = document.createElement('input');
+
+		close.type = 'button';
+		ok.type = 'submit';
+		input.type = 'text';
+		input.placeholder = defaultValue;
+		input.value = defaultValue;
+		input.name = 'result';
+
+		dialog.classList.add('animation-speed-normal', 'animation-ease-in', 'fadeInUp');
+
+		msg.textContent = text;
+		close.textContent = 'Cancel';
+		ok.textContent = 'Ok';
+		input.style.setProperty('margin-bottom', '12px');
+		ok.style.setProperty('margin-right', '8px');
+
+		dialog.addEventListener('close', event => event.target.remove());
+
+		close.addEventListener('click', event => {
+			event.target.closest('dialog[open]').close();
+			resolve(null);
+		});
+
+		form.addEventListener('submit', event => {
+			event.preventDefault();
+			const data = new FormData(event.target);
+			event.target.closest('dialog[open]').close();
+			resolve(data.get('result'));
+		});
+
+		form.append(input, document.createElement('br'), ok, close);
+
+		dialog.append(msg, form);
+		document.body.append(dialog);
+		dialog.showModal();
+		input.select();
+	});
+}


### PR DESCRIPTION
Using `<dialog>`  and `async` functions, this allows for constomization of such dialogs and does not stop script execution unless `await` is used.

Does not overwrite default functions, but can be made to do so:

```js
import {prompt, confirm, alert} from './asyncDialog.js';
window.alert = alert;
window.prompt = prompt;
window.confirm = confirm;
alert('This no longer stops execution and can be styled with CSS');
```