### PR TITLE
Improve `<dialog>` compatibility

### DIFF
--- a/asyncDialog.js
+++ b/asyncDialog.js
@@ -36,15 +36,19 @@ export async function confirm(text) {
 		close.textContent = 'Cancel';
 		ok.textContent = 'Ok';
 
-		dialog.addEventListener('close', event => event.target.remove());
+		dialog.addEventListener('close', event => {
+			event.target.remove();
+			resolve(!!event.returnValue);
+		});
+
 		close.addEventListener('click', event => {
 			event.target.closest('dialog[open]').close();
-			resolve(false);
 		});
+
 		ok.addEventListener('click', event => {
-			event.target.closest('dialog[open]').close();
-			resolve(true);
+			event.target.closest('dialog[open]').close('confirm');
 		});
+
 		dialog.append(msg, ok, close);
 		document.body.append(dialog);
 		dialog.showModal();

--- a/mutations.js
+++ b/mutations.js
@@ -171,6 +171,18 @@ export function init(base = document.body) {
 	$('[data-click]', base).each(el => clickHandler(el));
 	$('[data-copy]').click(handlers.copy);
 
+	if (document.createElement('dialog') instanceof HTMLUnknownElement) {
+		$('dialog form[method="dialog"]', base).submit(event => {
+			event.preventDefault();
+		}).then($forms => {
+			[...$forms].forEach(form => {
+				$('[type="submit"], button:not([type])', form).click(event => {
+					event.target.closest('dialog').close(event.target.value);
+				});
+			});
+		});
+	}
+
 	if (IntersectionObserver instanceof Function) {
 		$('[data-infinite-scroll]', base).intersect(infiniteScroll);
 		$('[data-load-from]', base).each(node => observer.observe(node));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "std-js",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A JavaScript library for making front-end development sane!",
   "keywords": [
     "ECMAScript2015",

--- a/shims.js
+++ b/shims.js
@@ -12,7 +12,13 @@ if (document.createElement('dialog') instanceof HTMLUnknownElement && !HTMLEleme
 	HTMLElement.prototype.close = function(returnValue = null) {
 		this.open = false;
 		if (this.tagName === 'DIALOG') {
-			this.dispatchEvent(new CustomEvent('close', {detail: returnValue}));
+			const event = new CustomEvent('close');
+			if (typeof returnValue === 'string') {
+				event.returnValue = true;
+				this.returnValue = returnValue;
+			}
+			this.dispatchEvent(event);
+			delete this.returnValue;
 		}
 	};
 

--- a/test/funcs.js
+++ b/test/funcs.js
@@ -105,7 +105,11 @@ ${event.get('event[address][street]')} ${event.get('event[address][city]')}, ${e
 
 	$(document.body).watch(mutations.events, mutations.options, mutations.filter);
 
-	$('dialog').on('close', event => console.log(event.target.returnValue));
+	$('dialog').on('close', event => {
+		if (event.returnValue) {
+			console.log(event.target.returnValue);
+		}
+	});
 
 	$('form[name="keybase-search"]').submit(keybaseSearch);
 


### PR DESCRIPTION
## Improve compatibility of `<dialog>` shim
### List of significant changes made
- Add support for `<form method=""dialog">`
- Correctly handle `returnValue` on close events
- Use `returnValue` to determine how to resolve `Promise` in `confirm` for `asyncDialog.js`