### PR TITLE
Fix detecting service worker support

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -300,7 +300,7 @@ export async function notify(title, {
 				});
 			}
 
-			if (navigator.hasOwnProperty('serviceWorker') && navigator.serviceWorker.controller !== null) {
+			if (('serviceWorker' in navigator) && navigator.serviceWorker.controller !== null) {
 				const reg = await navigator.serviceWorker.getRegistration();
 				await reg.showNotification(title, {
 					body,


### PR DESCRIPTION
Use `('serviceWorker' in navigator)`