### PR TITLE
Add shim for `navigator.connection`

### DIFF
--- a/shims.js
+++ b/shims.js
@@ -173,4 +173,4 @@ if (! ('connection' in navigator)) {
 	});
 } else if (! navigator.connection.hasOwnProperty('type')) {
 	navigator.connection.type = 'unknown';
-};
+}

--- a/shims.js
+++ b/shims.js
@@ -158,3 +158,19 @@ if (! HTMLLinkElement.prototype.hasOwnProperty('import')) {
 		}
 	});
 }
+
+if (! ('connection' in navigator)) {
+	navigator.connection = Object.freeze({
+		type: 'unknown',
+		effectiveType: '4g',
+		rtt: NaN,
+		downlink: NaN,
+		downlinkMax: Infinity,
+		saveData: false,
+		onchange: null,
+		ontypechange: null,
+		addEventListener: () => null,
+	});
+} else if (! navigator.connection.hasOwnProperty('type')) {
+	navigator.connection.type = 'unknown';
+};


### PR DESCRIPTION
This is hard-coded with the best defaults available.

Also sets `navigator.connection.type = 'unknown'` if not available.