### PR TITLE
Add shim for ParentNode.replaceChild()

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,9 +6,9 @@
     "extends": "eslint:recommended",
     "parserOptions": {
         "sourceType": "module",
-        "ecmaVersion": 2019
+        "ecmaVersion": 2018
     },
-    "plugins": ["async-await", "babel"],
+    "plugins": ["async-await"],
     "rules": {
         "indent": [
             2,
@@ -27,9 +27,5 @@
         "no-prototype-builtins": 0,
         "async-await/space-after-async": 2,
         "async-await/space-after-await": 2
-    },
-    "globals": {
-        "URLSearchParams": false,
-        "ga": false
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 <!-- markdownlint-disable -->
+## [v2.4.1] - 2020-07-09
+
+### Added
+- Single module as wrapper for `crypto.subtle.digest`
+- Shim for [`ParentNode.replaceChildren()`](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/replaceChildren)
+
+### Changed
+- Update eslint config and do not use project-wide globals
+
+### Removed
+- Uninstall eslint-babel plugin
+
 ## [v2.4.0] - 2020-06-27
 
 ### Added

--- a/analytics.js
+++ b/analytics.js
@@ -1,3 +1,4 @@
+/* global ga */
 export default (trackingCode) => {
 	((i, s, o, g, r, a, m) => {
 		i.GoogleAnalyticsObject = r;

--- a/hash.js
+++ b/hash.js
@@ -1,0 +1,271 @@
+export function sha1(data) {
+	return hash(data, 'SHA-1');
+}
+
+export function sha256(data) {
+	return hash(data, 'SHA-256');
+}
+
+export function sha384(data) {
+	return hash(data, 'SHA-384');
+}
+
+export function sha512(data) {
+	return hash(data, 'sha-512');
+}
+
+export async function hash(data, algo = 'SHA-1') {
+	if (typeof data === 'string') {
+		data = new TextEncoder().encode(data);
+	}
+	const buffer = await crypto.subtle.digest(algo.toUpperCase(), data);
+
+	return [...new Uint8Array(buffer)].map(value => {
+		const hexCode = value.toString(16).toUpperCase();
+		const paddedHexCode = hexCode.padStart(2, '0');
+		return paddedHexCode;
+	}).join('');
+}
+
+function safeAdd (x, y) {
+	var lsw = (x & 0xFFFF) + (y & 0xFFFF);
+	var msw = (x >> 16) + (y >> 16) + (lsw >> 16);
+	return (msw << 16) | (lsw & 0xFFFF);
+}
+
+/*
+* Bitwise rotate a 32-bit number to the left.
+*/
+function bitRotateLeft (num, cnt) {
+	return (num << cnt) | (num >>> (32 - cnt));
+}
+
+/*
+* These functions implement the four basic operations the algorithm uses.
+*/
+function md5cmn (q, a, b, x, s, t) {
+	return safeAdd(bitRotateLeft(safeAdd(safeAdd(a, q), safeAdd(x, t)), s), b);
+}
+function md5ff (a, b, c, d, x, s, t) {
+	return md5cmn((b & c) | ((~b) & d), a, b, x, s, t);
+}
+function md5gg (a, b, c, d, x, s, t) {
+	return md5cmn((b & d) | (c & (~d)), a, b, x, s, t);
+}
+function md5hh (a, b, c, d, x, s, t) {
+	return md5cmn(b ^ c ^ d, a, b, x, s, t);
+}
+function md5ii (a, b, c, d, x, s, t) {
+	return md5cmn(c ^ (b | (~d)), a, b, x, s, t);
+}
+
+/*
+* Calculate the MD5 of an array of little-endian words, and a bit length.
+*/
+function binlMD5 (x, len) {
+	/* append padding */
+	x[len >> 5] |= 0x80 << (len % 32);
+	x[(((len + 64) >>> 9) << 4) + 14] = len;
+
+	var i;
+	var olda;
+	var oldb;
+	var oldc;
+	var oldd;
+	var a = 1732584193;
+	var b = -271733879;
+	var c = -1732584194;
+	var d = 271733878;
+
+	for (i = 0; i < x.length; i += 16) {
+		olda = a;
+		oldb = b;
+		oldc = c;
+		oldd = d;
+
+		a = md5ff(a, b, c, d, x[i], 7, -680876936);
+		d = md5ff(d, a, b, c, x[i + 1], 12, -389564586);
+		c = md5ff(c, d, a, b, x[i + 2], 17, 606105819);
+		b = md5ff(b, c, d, a, x[i + 3], 22, -1044525330);
+		a = md5ff(a, b, c, d, x[i + 4], 7, -176418897);
+		d = md5ff(d, a, b, c, x[i + 5], 12, 1200080426);
+		c = md5ff(c, d, a, b, x[i + 6], 17, -1473231341);
+		b = md5ff(b, c, d, a, x[i + 7], 22, -45705983);
+		a = md5ff(a, b, c, d, x[i + 8], 7, 1770035416);
+		d = md5ff(d, a, b, c, x[i + 9], 12, -1958414417);
+		c = md5ff(c, d, a, b, x[i + 10], 17, -42063);
+		b = md5ff(b, c, d, a, x[i + 11], 22, -1990404162);
+		a = md5ff(a, b, c, d, x[i + 12], 7, 1804603682);
+		d = md5ff(d, a, b, c, x[i + 13], 12, -40341101);
+		c = md5ff(c, d, a, b, x[i + 14], 17, -1502002290);
+		b = md5ff(b, c, d, a, x[i + 15], 22, 1236535329);
+
+		a = md5gg(a, b, c, d, x[i + 1], 5, -165796510);
+		d = md5gg(d, a, b, c, x[i + 6], 9, -1069501632);
+		c = md5gg(c, d, a, b, x[i + 11], 14, 643717713);
+		b = md5gg(b, c, d, a, x[i], 20, -373897302);
+		a = md5gg(a, b, c, d, x[i + 5], 5, -701558691);
+		d = md5gg(d, a, b, c, x[i + 10], 9, 38016083);
+		c = md5gg(c, d, a, b, x[i + 15], 14, -660478335);
+		b = md5gg(b, c, d, a, x[i + 4], 20, -405537848);
+		a = md5gg(a, b, c, d, x[i + 9], 5, 568446438);
+		d = md5gg(d, a, b, c, x[i + 14], 9, -1019803690);
+		c = md5gg(c, d, a, b, x[i + 3], 14, -187363961);
+		b = md5gg(b, c, d, a, x[i + 8], 20, 1163531501);
+		a = md5gg(a, b, c, d, x[i + 13], 5, -1444681467);
+		d = md5gg(d, a, b, c, x[i + 2], 9, -51403784);
+		c = md5gg(c, d, a, b, x[i + 7], 14, 1735328473);
+		b = md5gg(b, c, d, a, x[i + 12], 20, -1926607734);
+
+		a = md5hh(a, b, c, d, x[i + 5], 4, -378558);
+		d = md5hh(d, a, b, c, x[i + 8], 11, -2022574463);
+		c = md5hh(c, d, a, b, x[i + 11], 16, 1839030562);
+		b = md5hh(b, c, d, a, x[i + 14], 23, -35309556);
+		a = md5hh(a, b, c, d, x[i + 1], 4, -1530992060);
+		d = md5hh(d, a, b, c, x[i + 4], 11, 1272893353);
+		c = md5hh(c, d, a, b, x[i + 7], 16, -155497632);
+		b = md5hh(b, c, d, a, x[i + 10], 23, -1094730640);
+		a = md5hh(a, b, c, d, x[i + 13], 4, 681279174);
+		d = md5hh(d, a, b, c, x[i], 11, -358537222);
+		c = md5hh(c, d, a, b, x[i + 3], 16, -722521979);
+		b = md5hh(b, c, d, a, x[i + 6], 23, 76029189);
+		a = md5hh(a, b, c, d, x[i + 9], 4, -640364487);
+		d = md5hh(d, a, b, c, x[i + 12], 11, -421815835);
+		c = md5hh(c, d, a, b, x[i + 15], 16, 530742520);
+		b = md5hh(b, c, d, a, x[i + 2], 23, -995338651);
+
+		a = md5ii(a, b, c, d, x[i], 6, -198630844);
+		d = md5ii(d, a, b, c, x[i + 7], 10, 1126891415);
+		c = md5ii(c, d, a, b, x[i + 14], 15, -1416354905);
+		b = md5ii(b, c, d, a, x[i + 5], 21, -57434055);
+		a = md5ii(a, b, c, d, x[i + 12], 6, 1700485571);
+		d = md5ii(d, a, b, c, x[i + 3], 10, -1894986606);
+		c = md5ii(c, d, a, b, x[i + 10], 15, -1051523);
+		b = md5ii(b, c, d, a, x[i + 1], 21, -2054922799);
+		a = md5ii(a, b, c, d, x[i + 8], 6, 1873313359);
+		d = md5ii(d, a, b, c, x[i + 15], 10, -30611744);
+		c = md5ii(c, d, a, b, x[i + 6], 15, -1560198380);
+		b = md5ii(b, c, d, a, x[i + 13], 21, 1309151649);
+		a = md5ii(a, b, c, d, x[i + 4], 6, -145523070);
+		d = md5ii(d, a, b, c, x[i + 11], 10, -1120210379);
+		c = md5ii(c, d, a, b, x[i + 2], 15, 718787259);
+		b = md5ii(b, c, d, a, x[i + 9], 21, -343485551);
+
+		a = safeAdd(a, olda);
+		b = safeAdd(b, oldb);
+		c = safeAdd(c, oldc);
+		d = safeAdd(d, oldd);
+	}
+	return [a, b, c, d];
+}
+
+/*
+* Convert an array of little-endian words to a string
+*/
+function binl2rstr (input) {
+	var i;
+	var output = '';
+	var length32 = input.length * 32;
+	for (i = 0; i < length32; i += 8) {
+		output += String.fromCharCode((input[i >> 5] >>> (i % 32)) & 0xFF);
+	}
+	return output;
+}
+
+/*
+* Convert a raw string to an array of little-endian words
+* Characters >255 have their high-byte silently ignored.
+*/
+function rstr2binl (input) {
+	var i;
+	var output = [];
+	output[(input.length >> 2) - 1] = undefined;
+	for (i = 0; i < output.length; i += 1) {
+		output[i] = 0;
+	}
+	var length8 = input.length * 8;
+	for (i = 0; i < length8; i += 8) {
+		output[i >> 5] |= (input.charCodeAt(i / 8) & 0xFF) << (i % 32);
+	}
+	return output;
+}
+
+/*
+* Calculate the MD5 of a raw string
+*/
+function rstrMD5 (s) {
+	return binl2rstr(binlMD5(rstr2binl(s), s.length * 8));
+}
+
+/*
+* Calculate the HMAC-MD5, of a key and some data (raw strings)
+*/
+function rstrHMACMD5 (key, data) {
+	var i;
+	var bkey = rstr2binl(key);
+	var ipad = [];
+	var opad = [];
+	var hash;
+	ipad[15] = opad[15] = undefined;
+	if (bkey.length > 16) {
+		bkey = binlMD5(bkey, key.length * 8);
+	}
+	for (i = 0; i < 16; i += 1) {
+		ipad[i] = bkey[i] ^ 0x36363636;
+		opad[i] = bkey[i] ^ 0x5C5C5C5C;
+	}
+	hash = binlMD5(ipad.concat(rstr2binl(data)), 512 + data.length * 8);
+	return binl2rstr(binlMD5(opad.concat(hash), 512 + 128));
+}
+
+/*
+* Convert a raw string to a hex string
+*/
+function rstr2hex (input) {
+	var hexTab = '0123456789abcdef';
+	var output = '';
+	var x;
+	var i;
+	for (i = 0; i < input.length; i += 1) {
+		x = input.charCodeAt(i);
+		output += hexTab.charAt((x >>> 4) & 0x0F) +
+				hexTab.charAt(x & 0x0F);
+	}
+	return output;
+}
+
+/*
+* Encode a string as utf-8
+*/
+function str2rstrUTF8 (input) {
+	return unescape(encodeURIComponent(input));
+}
+
+/*
+* Take string arguments and return either raw or hex encoded strings
+*/
+function rawMD5 (s) {
+	return rstrMD5(str2rstrUTF8(s));
+}
+function hexMD5 (s) {
+	return rstr2hex(rawMD5(s));
+}
+function rawHMACMD5 (k, d) {
+	return rstrHMACMD5(str2rstrUTF8(k), str2rstrUTF8(d));
+}
+function hexHMACMD5 (k, d) {
+	return rstr2hex(rawHMACMD5(k, d));
+}
+
+export async function md5 (string, key, raw) {
+	if (!key) {
+		if (!raw) {
+			return hexMD5(string);
+		}
+		return rawMD5(string);
+	}
+	if (!raw) {
+		return hexHMACMD5(key, string);
+	}
+	return rawHMACMD5(key, string);
+}

--- a/hash.js
+++ b/hash.js
@@ -24,7 +24,7 @@ export async function hash(data, algo = 'SHA-1') {
 		const hexCode = value.toString(16).toUpperCase();
 		const paddedHexCode = hexCode.padStart(2, '0');
 		return paddedHexCode;
-	}).join('');
+	}).join('').toLowerCase();
 }
 
 function safeAdd (x, y) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -368,21 +368,6 @@
       "integrity": "sha1-DyrhejgUeAY11I8kCd+eN4mMoJ8=",
       "dev": true
     },
-    "eslint-plugin-babel": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-5.3.1.tgz",
-      "integrity": "sha512-VsQEr6NH3dj664+EyxJwO4FCYm/00JhYb3Sk3ft8o+fpKuIfQ9TaW6uVUfvwMXHcf/lsnRIoyFPsLMyiWCSL/g==",
-      "dev": true,
-      "requires": {
-        "eslint-rule-composer": "^0.3.0"
-      }
-    },
-    "eslint-rule-composer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
-      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
-      "dev": true
-    },
     "eslint-scope": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "devDependencies": {
     "eslint": "^7.3.1",
     "eslint-plugin-async-await": "0.0.0",
-    "eslint-plugin-babel": "^5.3.0",
     "http-server": "^0.12.3"
   },
   "dependencies": {}

--- a/sha1.js
+++ b/sha1.js
@@ -1,10 +1,5 @@
+import { hash } from './hash.js';
+
 export default async function sha1(str) {
-	return await crypto.subtle.digest('SHA-1', new TextEncoder().encode(str))
-		.then(buffer => {
-			return [...new Uint8Array(buffer)].map(value => {
-				const hexCode = value.toString(16).toUpperCase();
-				const paddedHexCode = hexCode.padStart(2, '0');
-				return paddedHexCode;
-			}).join('');
-		});
+	return hash(str, 'SHA-1');
 }

--- a/shims.js
+++ b/shims.js
@@ -1,5 +1,29 @@
 import Notification from './Notification.js';
 
+if (! (Element.prototype.replaceChildren instanceof Function)) {
+	Element.prototype.replaceChildren = function(...items) {
+		[...this.children].forEach(el => el.remove());
+		this.append(...items);
+	};
+
+	Document.prototype.replaceChildren = function(...items) {
+		[...this.children].forEach(el => el.remove());
+		this.append(...items);
+	};
+
+	DocumentFragment.prototype.replaceChildren = function(...items) {
+		[...this.children].forEach(el => el.remove());
+		this.append(...items);
+	};
+
+	if ('ShadowRoot' in window) {
+		ShadowRoot.prototype.replaceChildren = function(...items) {
+			[...this.children].forEach(el => el.remove());
+			this.append(...items);
+		};
+	}
+}
+
 if (! window.hasOwnProperty('CustomEvent')) {
 	window.CustomEvent = class CustomEvent {
 		constructor(event, {

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,10 @@
 import '../shims.js';
 import '../deprefixer.js';
-import {loadHandler} from './funcs.js';
+import { loadHandler } from './funcs.js';
+import { $, ready } from '../functions.js';
 import kbdShortcuts from '../kbd_shortcuts.js';
-import {$, ready} from '../functions.js';
+
+document.documentElement.classList.toggle('no-dialog', document.createElement('dialog') instanceof HTMLUnknownElement);
 
 ready().then(async () => {
 	const $body = $('body');


### PR DESCRIPTION
## [v2.4.1] - 2020-07-09

### Added
- Single module as wrapper for `crypto.subtle.digest`
- Shim for [`ParentNode.replaceChildren()`](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/replaceChildren)

### Changed
- Update eslint config and do not use project-wide globals

### Removed
- Uninstall eslint-babel plugin