### PR TITLE
Add Notification shim for Android Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Notification shim using `<html-notification>`, checking for false support (Chrome Android)
+
 ### Changed
 - Update `.editorconfig` to specifiy tab style and width
 

--- a/notification-shim.js
+++ b/notification-shim.js
@@ -1,6 +1,6 @@
 import { HTMLNotificationElement } from 'https://cdn.kernvalley.us/components/notification/html-notification.js';
 
-function supportsNotification() {
+export function supportsNotification() {
 	try {
 		if ('Notification' in window) {
 			new Notification('');

--- a/notification-shim.js
+++ b/notification-shim.js
@@ -16,3 +16,11 @@ export function supportsNotification() {
 if (! supportsNotification()) {
 	window.Notification = HTMLNotificationElement;
 }
+
+export function notify(title, init = {}) {
+	if (Notification.permission === 'granted') {
+		return new Notification(title, init);
+	} else {
+		return new HTMLNotificationElement(title, init);
+	}
+}

--- a/notification-shim.js
+++ b/notification-shim.js
@@ -1,0 +1,18 @@
+import { HTMLNotificationElement } from 'https://cdn.kernvalley.us/components/notification/html-notification.js';
+
+function supportsNotification() {
+	try {
+		if ('Notification' in window) {
+			new Notification('');
+			return Notification.permission !== 'denied';
+		} else {
+			return false;
+		}
+	} catch(err) {
+		return ! (err instanceof TypeError);
+	}
+}
+
+if (! supportsNotification()) {
+	window.Notification = HTMLNotificationElement;
+}

--- a/shims.js
+++ b/shims.js
@@ -1,5 +1,3 @@
-import Notification from './Notification.js';
-
 if (! (navigator.setAppBadge instanceof Function)) {
 	navigator.setAppBadge = () => Promise.reject('Not Supported');
 }
@@ -44,10 +42,6 @@ if (! window.hasOwnProperty('CustomEvent')) {
 			return evt;
 		}
 	};
-}
-
-if (! window.hasOwnProperty('Notification')) {
-	window.Notification = Notification;
 }
 
 if (window.hasOwnProperty('Animation') && ! Animation.prototype.hasOwnProperty('finished')) {


### PR DESCRIPTION
Use HTMLNotificationElement if notification permission denied or if Chrome on Android, which lies about support for Notifications.