### PR TITLE
Add functionality reloating to IntersectionObserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2.5.2 - 2020-09-09
+
 ### Added
 - `navigator.getInstalledRelatedApps()` shim
 - Add `UTM` generator and validator class, extending `URL`
@@ -14,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `preload()` function, creating a `<link rel="preload">`
 - Add `parseHTML()` function, which parses text and returns a document fragment
 - More functions for other preloading techniques
+- Add module containing functions to wait for visibility in viewport
+- Add function to check if an element is visible withing the viewport (no waiting)
+- Create function to get bounds of current viewport
+
+### Changed
+- Update `$.visible()` to be more similar to jQuery's `.visible()`
+- Make `$.matches()` able to test all elements or any element
 
 ## [v2.5.1] - 2020-08-21
 

--- a/esQuery.js
+++ b/esQuery.js
@@ -1,5 +1,4 @@
-import { read, debounce, prefersReducedMotion } from './functions.js';
-
+import { read, debounce, prefersReducedMotion, isInViewport } from './functions.js';
 const PREFIXES = [
 	'',
 	'moz',
@@ -80,12 +79,12 @@ export default class esQuery extends Set {
 		return this;
 	}
 
-	async visible() {
-		return this.css({ visibility: 'visible' });
-	}
-
-	async invisible() {
-		return this.css({ visibility: 'hidden' });
+	async visible(any = false) {
+		if (any) {
+			return this.some(isInViewport);
+		} else {
+			return this.every(isInViewport);
+		}
 	}
 
 	async each(callback, thisArg = this) {
@@ -129,8 +128,12 @@ export default class esQuery extends Set {
 		return new esQuery([...this].map(el => el.closest(selector)));
 	}
 
-	async matches(selector) {
-		return this.every(el => el.matches(selector));
+	async matches(selector, any = false) {
+		if (any) {
+			return this.some(el => el.matches(selector));
+		} else {
+			return this.every(el => el.matches(selector));
+		}
 	}
 
 	/**

--- a/functions.js
+++ b/functions.js
@@ -1,5 +1,9 @@
 import esQuery from './esQuery.js';
 
+export function between(min, val, max) {
+	return val >= min && val <= max;
+}
+
 export function clone(thing) {
 	if (thing instanceof Array) {
 		return [...thing].map(clone);
@@ -37,6 +41,20 @@ export function displayMode() {
 	return typeof matchMedia === 'function'
 		? displays.find(mode => matchMedia(`(display-mode: ${mode})`).matches)
 		: 'browser';
+}
+
+export function isInViewport(el) {
+	if (typeof el === 'string') {
+		return isInViewport(document.querySelector(el));
+	} else if (el instanceof Element) {
+		const { top, bottom, left, right } = el.getBoundingClientRect();
+		const { height, width } = screen;
+
+		return (between(0, top, height) || between(0, bottom, height))
+			&& (between(0, left, width) || between(0, right, width));
+	} else {
+		throw new Error('Not a valid element or selector');
+	}
 }
 
 export function registerCustomElement(tag, cls, ...rest) {

--- a/viewport.js
+++ b/viewport.js
@@ -1,0 +1,93 @@
+import { isInViewport } from './functions.js';
+
+let observer   = null;
+const intEls   = new WeakMap();
+const unIntEls = new WeakMap();
+
+async function observe(el, intersecting = true) {
+	return await new Promise((resolve, reject) => {
+		const elIsIntersecting = isInViewport(el);
+
+		if (intersecting && elIsIntersecting) {
+			resolve(el);
+		} else if (! intersecting && ! elIsIntersecting) {
+			resolve(el);
+		} else if (! intersectionObserverSupported()) {
+			reject(new Error('IntersectionObserver not supported'));
+		} else {
+			if (! (observer instanceof IntersectionObserver)) {
+				observer = new IntersectionObserver((entries, observer) => {
+					entries.forEach(({ target, isIntersecting }) => {
+						if (isIntersecting) {
+							const prom = intEls.get(target);
+
+							if (prom instanceof Function) {
+								prom(target);
+								intEls.delete(target);
+
+								if (! unIntEls.has(target)) {
+									observer.unobserve(target);
+								}
+							}
+						} else {
+							const prom = unIntEls.get(target);
+
+							if (prom instanceof Function) {
+								prom(target);
+								unIntEls.delete(target);
+
+								if (! intEls.has(target)) {
+									observer.unobserve(target);
+								}
+							}
+						}
+					});
+				});
+			}
+
+			if (intersecting) {
+				intEls.set(el, resolve);
+				observer.observe(el);
+			} else {
+				unIntEls.set(el, resolve);
+				observer.observe(el);
+			}
+		}
+	});
+}
+
+export function intersectionObserverSupported() {
+	return 'IntersectionObserver' in window;
+}
+
+export function getViewportBounds() {
+	const { height, width } = screen;
+	return [
+		[scrollX, scrollY],
+		[scrollX + width, scrollY],
+		[scrollX + width, scrollY + height],
+		[scrollX, scrollY + height]
+	];
+}
+
+export async function whenInViewport(el) {
+	if (typeof el === 'string') {
+		return whenInViewport(document.querySelector(el));
+	} else if (! (el instanceof Element)) {
+		throw new Error('Invalid element or selector');
+	} else if (isInViewport(el)) {
+		return el;
+	} else {
+		return await observe(el, true);
+	}
+}
+
+export async function whenNotInViewport(el) {
+	if (typeof el === 'string') {
+		return whenNotInViewport(document.querySelector(el));
+	} else if (! isInViewport(el)) {
+		return el;
+	} else {
+		return await observe(el, false);
+	}
+}


### PR DESCRIPTION
- Add module containing functions to wait for visibility in viewport
- Add function to check if an element is visible withing the viewport (no waiting)
- Update `$.visible()` to be more similar to jQuery's `.visible()`
- Make `$.matches()` able to test all elements or any element