### PR TITLE
Fix passing args

### DIFF
--- a/viewport.js
+++ b/viewport.js
@@ -94,7 +94,7 @@ export async function whenNotInViewport(el) {
 
 export async function whenInViewportFor(el, ms = 1000) {
 	if (typeof el === 'string') {
-		return whenInViewportFor(document.querySelector(el, ms));
+		return whenInViewportFor(document.querySelector(el), ms);
 	} else if (! (el instanceof Element)) {
 		throw new Error('Invalid element or selector');
 	} else {


### PR DESCRIPTION
Pass `ms` to `whenInViewportFor()` instead of `querySelector()`