### PR TITLE
Update `$.on()` & `$.off()` to handle multiple events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Get existing cookie when deleting them (for change events)
 - Normalize params for `CookieStore`
+- `$.on()` and `$.off()` now also accept an array of events or an object of `{ event: callback }`
 
 ### Fixed
 - Update `cookieStore` to match behavior experienced in Origin-Trail in Chrome

--- a/esQuery.js
+++ b/esQuery.js
@@ -981,13 +981,25 @@ export default class esQuery extends Set {
 	}
 
 	/*==================== Listener Functions =================================*/
-	async on(event, callback, ...args) {
-		this.forEach(node => node.addEventListener(event, callback, ...args));
+	async on(event, ...args) {
+		if (typeof event === 'string') {
+			this.forEach(node => node.addEventListener(event, ...args));
+		} else if (Array.isArray(event)) {
+			event.forEach(e => this.on(e, ...args));
+		} else {
+			Object.entries(event).forEach(([e, c]) => this.on(e, c, ...args));
+		}
 		return this;
 	}
 
-	async off(event, callback, ...args) {
-		this.forEach(node => node.removeEventListener(event, callback, ...args));
+	async off(event, ...args) {
+		if (typeof event === 'string') {
+			this.forEach(node => node.removeEventListener(event, ...args));
+		} else if (Array.isArray(event)) {
+			event.forEach(e => this.off(e, ...args));
+		} else {
+			Object.entries(event).forEach(([e, c]) => this.off(e, c, ...args));
+		}
 		return this;
 	}
 


### PR DESCRIPTION
`$.on()` and `$.off()` now also accept an array of events or an object of `{ event: callback }`

```js
$('.selector').on(['click', 'dblclick'], handler, { passive: true });
$('.other').on({ contextmenu: console.log, mouseenter: myFunc);
```