### PR TITLE
Deprecate and update functions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,9 +6,9 @@
     "extends": "eslint:recommended",
     "parserOptions": {
         "sourceType": "module",
-        "ecmaVersion": 2018
+        "ecmaVersion": 2020
     },
-    "plugins": ["async-await"],
+    "plugins": [],
     "rules": {
         "indent": [
             2,
@@ -27,9 +27,7 @@
         ],
         "no-console": 0,
         "no-async-promise-executor": 0,
-        "no-prototype-builtins": 0,
-        "async-await/space-after-async": 2,
-        "async-await/space-after-await": 2
+        "no-prototype-builtins": 0
     },
     "globals": {
       "cookieStore": "readonly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.6.0] - 2020-12-07
+
 ### Added
 - Create script with event(click) handlers using `data-*` attributes
 - Create module for working with files, consisting of `open()` and `save()` functions
+- Add `ready`, `loaded`, `mediaQuery`, & `getLocation` static methods to `esQuery`
+
+### Changed
+- Move deprecated function in `functions.js` to separate script
+- Set `esQuery` static methods on the `$` function when exporting
+- Rename `wait()` to `sleep()` and alias old function with warning
+- Misc. updates to reuse functions instead of repeating them
+- Update linting & dependencies
 
 ## [v2.5.4] - 2020-12-01
 

--- a/Notification.js
+++ b/Notification.js
@@ -1,7 +1,4 @@
-function css(element, props) {
-	Object.entries(props).forEach(([key, value]) => element.style.setProperty(key, value));
-	return element;
-}
+import { css } from './functions.js';
 
 export default class Notification {
 	constructor(title, {

--- a/UTM.js
+++ b/UTM.js
@@ -98,12 +98,16 @@ export default class UTM extends URL {
 		return this.searchParams.has('utm_source');
 	}
 
-	clear() {
+	clear(replaceState = false) {
 		this.searchParams.delete('utm_source');
 		this.searchParams.delete('utm_medium');
 		this.searchParams.delete('utm_campaign');
 		this.searchParams.delete('utm_content');
 		this.searchParams.delete('utm_term');
+
+		if (replaceState) {
+			history.replaceState(history.state, document.title, this.href);
+		}
 		return this;
 	}
 }

--- a/dataHandlers.js
+++ b/dataHandlers.js
@@ -1,7 +1,8 @@
 /**
  * HTML API using data-* attributes
  */
-import {selectElement} from './functions.js';
+import {selectElement} from './deprecatedFunctions.js';
+
 export function copy() {
 	let el = null;
 	if (this.dataset.copy.length) {

--- a/deprecatedFunctions.js
+++ b/deprecatedFunctions.js
@@ -1,0 +1,357 @@
+import { $, sleep, toGenerator } from './functions.js';
+/**
+ * @deprecated [will be removed in v3.0.0]
+ */
+export function reportError(err) {
+	console.warn('`reportError()` is deprecated and will be removed');
+	if (err instanceof ErrorEvent) {
+		const url = new URL('Errors/Client/', document.documentElement.dataset.endpoint || 'https://api.kernvalley.us');
+		const data = new FormData();
+		data.set('name', err.type);
+		data.set('message', err.message);
+		data.set('lineNumber', err.lineno);
+		data.set('columnNumber', err.colno);
+		data.set('fileName', err.filename);
+		return navigator.sendBeacon(url, data);
+	} else {
+		return false;
+	}
+}
+
+/**
+ * @deprecated [will be removed in v3.0.0]
+ */
+export async function importsLoaded() {
+	console.warn('`importsLoaded()` is deprecated and will be removed');
+	await $('link[rel~="import"]:not([async])').map(async link => {
+		if (link.import === null) {
+			await new Promise((resolve, reject) => {
+				link.addEventListener('load', () => resolve());
+				link.addEventListener('error', reject);
+			});
+		}
+	});
+}
+
+/**
+ * @deprecated [will be removed in v3.0.0]
+ */
+export async function getImports() {
+	console.warn('`getImports()` is deprecated and will be removed');
+	await importsLoaded();
+	const imports = await $('link[rel~="import"][name]').map(link => link.getAttribute('name'));
+	return await Promise.all(imports.map(async name => ({ name, content: await importLink(name) })));
+}
+
+/**
+ * @deprecated [will be removed in v3.0.0]
+ */
+export async function importLink(name) {
+	console.warn('`importLink()` is deprecated and will be removed');
+	await importsLoaded();
+	const link = document.querySelector(`link[rel~="import"][name="${name}"]`);
+	if (link instanceof HTMLLinkElement) {
+		return new Promise((resolve, reject) => {
+			link.addEventListener('error', reject);
+			if (link.import === null) {
+				link.addEventListener('load', () => resolve(link.import), { once: true });
+			} else {
+				resolve(link.import);
+			}
+		});
+	} else {
+		throw new Error(`Link named "${name}" has no content to import`);
+	}
+}
+
+/**
+ * @deprecated [will be removed in v3.0.0]
+ */
+export function selectElement(el) {
+	console.warn('`selectElement()` is deprecated and will be removed');
+	if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+		el.select();
+	} else if (window.getSelection) {
+		const selection = getSelection();
+		const range = document.createRange();
+		range.selectNodeContents(el);
+		selection.removeAllRanges();
+		selection.addRange(range);
+	} else if (document.body.createTextRange) {
+		const range = document.body.createTextRange();
+		range.moveToElementText(el);
+		range.select();
+	} else {
+		throw new Error('Text selection is not supported');
+	}
+}
+
+/**
+ * @deprecated [will be removed in v3.0.0]
+ */
+export async function imgur(url, {
+	sizes = ['100vw'],
+	alt = '',
+	defaultSize = 'h',
+} = {}) {
+	console.warn('`imgur()` is deprecated and will be removed');
+	const imgurSizes = {
+		h: 1024,
+		l: 640,
+		m: 320,
+		t: 160,
+	};
+
+	const formats = {
+		'image/webp': '.webp',
+		'image/png': '.png',
+	};
+
+	const picture = document.createElement('picture');
+	const imgur = new URL(url, 'https://i.imgur.com/');
+	const image = new Image();
+
+
+	imgur.host = 'i.imgur.com';
+	imgur.protocol = 'https:';
+	imgur.pathname = imgur.pathname.replace(/\.[A-z]+$/, '');
+	Object.entries(formats).forEach(format => {
+		const [type, ext] = format;
+		const source = document.createElement('source');
+		source.type = type;
+		source.sizes = sizes.join(', ');
+		const srcset = Object.entries(imgurSizes).map(size => {
+			const [suffix, width] = size;
+			return `${imgur}${suffix}${ext} ${width}w`;
+		});
+		source.srcset = srcset.join(', ');
+		picture.append(source);
+	});
+
+	return new Promise((resolve, reject) => {
+		picture.append(image);
+		image.alt = alt;
+		image.addEventListener('load', (event) => resolve(event.target.parentElement), { once: true });
+		image.addEventListener('error', event => reject(event.target));
+		image.src = `${imgur}${defaultSize}.png`;
+	});
+}
+
+/**
+ * @deprecated [will be removed in v3.0.0]
+ */
+export function query(selector, node = document) {
+	console.warn('`query()` is deprecated and will be removed');
+	let results = Array.from(node.querySelectorAll(selector));
+	if (node.matches(selector)) {
+		results.unshift(node);
+	}
+	return results;
+}
+
+/**
+ * @deprecated [will be removed in v3.0.0]
+ */
+export function isOnline() {
+	console.warn('`isOnline()` is deprecated and will be removed');
+	return navigator.onLine === true;
+}
+
+/**
+ * @deprecated [will be removed in v3.0.0]
+ */
+export async function notify(title, {
+	body = '',
+	icon = '',
+	dir = document.dir,
+	lang = document.documentElement.lang,
+	tag = '',
+	data = null,
+	vibrate = false,
+	renotify = false,
+	requireInteraction = false,
+	actions = [],
+	silent = false,
+	noscreen = false,
+	sticky = false,
+} = {}) {
+	console.warn('`notify()` is deprecated and will be removed');
+	return new Promise(async (resolve, reject) => {
+		try {
+			if (!(window.Notification instanceof Function)) {
+				throw new Error('Notifications not supported');
+			} else if (Notification.permission === 'denied') {
+				throw new Error('Notification permission denied');
+			} else if (Notification.permission === 'default') {
+				await new Promise(async (resolve, reject) => {
+					const resp = await Notification.requestPermission();
+
+					if (resp === 'granted') {
+						resolve();
+					} else {
+						reject(new Error('Notification permission not granted'));
+					}
+				});
+			}
+
+			if (('serviceWorker' in navigator) && navigator.serviceWorker.controller !== null) {
+				const reg = await navigator.serviceWorker.getRegistration();
+				await reg.showNotification(title, {
+					body,
+					icon,
+					dir,
+					lang,
+					tag,
+					actions,
+					data,
+					vibrate,
+					renotify,
+					requireInteraction,
+					silent,
+					noscreen,
+					sticky,
+				});
+				const notifications = await reg.getNotifications();
+				resolve(notifications[notifications.length - 1]);
+			} else {
+				const notification = new Notification(title, {
+					body,
+					icon,
+					dir,
+					lang,
+					tag,
+					data,
+					vibrate,
+					renotify,
+					requireInteraction,
+					actions,
+					silent,
+					noscreen,
+					sticky,
+				});
+
+				notification.addEventListener('show', event => resolve(event.target), { once: true });
+				notification.addEventListener('error', event => reject(event.target), { once: true });
+			}
+
+		} catch (err) {
+			reject(err);
+		}
+	});
+}
+
+/**
+ * @deprecated [will be removed in v3.0.0]
+ */
+export function isInternalLink(link) {
+	console.warn('`isInternalLink()` is deprecated and will be removed');
+	return link.origin === location.origin;
+}
+
+/**
+ * @deprecated [will be removed in v3.0.0]
+ */
+export async function parseResponse(resp) {
+	console.warn('`parseResponse()` is deprecated and will be removed');
+	if (! resp.headers.has('Content-Type')) {
+		throw new Error(`No Content-Type header in request to "${resp.url}"`);
+	} else if (resp.headers.get('Content-Length') === 0) {
+		throw new Error(`No response body for "${resp.url}"`);
+	}
+
+	const type = resp.headers.get('Content-Type');
+
+	if (type.startsWith('application/json')) {
+		return resp.json();
+	} else if (type.startsWith('application/xml')) {
+		return new DOMParser().parseFromString(await resp.text(), 'application/xml');
+	} else if (type.startsWith('image/svg+xml')) {
+		return new DOMParser().parseFromString(await resp.text(), 'image/svg+xml');
+	} else if (type.startsWith('text/html')) {
+		return new DOMParser().parseFromString(await resp.text(), 'text/html');
+	} else if (type.startsWith('text/plain')) {
+		return resp.text();
+	} else {
+		throw new TypeError(`Unsupported Content-Type: ${type}`);
+	}
+}
+
+/**
+ * @deprecated [will be removed in v3.0.0]
+ */
+export async function registerServiceWorker(path) {
+	console.warn('`registerServiceWorker()` is deprecated and will be removed');
+	return new Promise(async (resolve, reject) => {
+		try {
+			if (!Navigator.prototype.hasOwnProperty('serviceWorker')) {
+				throw new Error('Service worker not supported');
+			} else if (!navigator.onLine) {
+				throw new Error('Offline');
+			}
+
+			const url = new URL(path, document.baseURI);
+			const reg = await navigator.serviceWorker.register(url, { scope: document.baseURI });
+
+			if (navigator.onLine) {
+				reg.update();
+			}
+
+			reg.addEventListener('updatefound', event => resolve(event.target));
+			reg.addEventListener('install', event => resolve(event.target));
+			reg.addEventListener('activate', event => resolve(event.target));
+			reg.addEventListener('error', event => reject(event.target));
+			reg.addEventListener('fetch', console.info);
+		} catch (error) {
+			reject(error);
+		}
+	});
+}
+
+/**
+ * @deprecated [will be removed in v3.0.0]
+ */
+export async function marquee({
+	parent,
+	delay = 200,
+	cursor = '|',
+	blinkRate = 800,
+	pause = 1000,
+	containerTag = 'span',
+	cursorTag = 'span',
+} = {}, ...sentences) {
+	console.warn('`marquee()` is deprecated and will be removed');
+	const cursorEl = document.createElement(cursorTag);
+	const container = document.createElement(containerTag);
+
+	if (Element.prototype.animate) {
+		cursorEl.animate([
+			{ opacity: 0 },
+			{ opacity: 1 }
+		], {
+			duration: blinkRate,
+			iterations: Infinity,
+			direction: 'alternate',
+		});
+	}
+
+	cursorEl.textContent = cursor;
+	parent.prepend(container, cursorEl);
+
+	for (const text of toGenerator(...sentences)) {
+		container.textContent = '';
+
+		for (const char of text.split('')) {
+			container.append(char);
+			await sleep(delay);
+		}
+
+		await sleep(pause);
+
+		while (container.textContent !== '') {
+			const chars = container.textContent.split('');
+			chars.pop();
+			container.textContent = chars.join('');
+			await sleep(delay);
+		}
+	}
+}

--- a/esQuery.js
+++ b/esQuery.js
@@ -1,5 +1,6 @@
 import { attr, css, data, toggleClass, on, off, read, debounce,
-	prefersReducedMotion, isInViewport } from './functions.js';
+	prefersReducedMotion, isInViewport, mediaQuery, getLocation, ready, loaded }
+	from './functions.js';
 
 const PREFIXES = [
 	'',
@@ -142,6 +143,7 @@ export default class esQuery extends Set {
 	 * @deprecated [will be removed in v3.0.0]
 	 */
 	async import(selector = 'body > *') {
+		console.warn('`esQuery.import()` is deprecated and will be removed');
 		const imports = this.toArray().filter(node => node.tagName === 'LINK'
 			&& node.relList.contains('import'));
 		const docs = await Promise.all(imports.map(link => {
@@ -170,7 +172,9 @@ export default class esQuery extends Set {
 	}
 
 	async animate(keyframes, opts = 400) {
-		if (('animate' in Element.prototype) && !prefersReducedMotion()) {
+		if (typeof keyframes === 'string') {
+			return this.css({ 'animation-name': keyframes });
+		} else if (('animate' in Element.prototype) && ! prefersReducedMotion()) {
 			await this.map(node => node.animate(keyframes, opts).finished);
 			return this;
 		} else {
@@ -219,6 +223,7 @@ export default class esQuery extends Set {
 		to = 'none',
 		id = 'grayscale',
 	} = {}) {
+		console.warn('`esQuery.animateFilter()` is deprecated and will be removed');
 		return this.animate([
 			{ filter: `${from}` },
 			{ filter: `${to}` },
@@ -247,6 +252,7 @@ export default class esQuery extends Set {
 		to = '0.5em 0.5em 0.5em rgba(0,0,0,0.3)',
 		id = 'drop-shadow',
 	} = {}) {
+		console.warn('`esQuery.anifilterDropShadow()` is deprecated and will be removed');
 		return this.animate([
 			{ filter: `drop-shadow(${from})` },
 			{ filter: `drop-shadow(${to})` },
@@ -275,6 +281,7 @@ export default class esQuery extends Set {
 		to = 1,
 		id = 'grayscale',
 	} = {}) {
+		console.warn('`esQuery.filterGrayScale()` is deprecated and will be removed');
 		return this.animateFilter({
 			from: `grayscale(${from})`,
 			to: `grayscale(${to})`,
@@ -302,6 +309,7 @@ export default class esQuery extends Set {
 		to = '5px',
 		id = 'blur',
 	} = {}) {
+		console.warn('`esQuery.filterBlur()` is deprecated and will be removed');
 		return this.animateFilter({
 			from: `blur(${from})`,
 			to: `blur(${to})`,
@@ -329,6 +337,7 @@ export default class esQuery extends Set {
 		to = '100%',
 		id = 'invert',
 	} = {}) {
+		console.warn('`esQuery.filterInvert()` is deprecated and will be removed');
 		return this.animateFilter({
 			from: `invert(${from})`,
 			to: `invert(${to})`,
@@ -356,6 +365,7 @@ export default class esQuery extends Set {
 		to = '90deg',
 		id = 'hue-rotate',
 	} = {}) {
+		console.warn('`esQuery.filterHueRotate()` is deprecated and will be removed');
 		return this.animateFilter({
 			from: `hue-rotate(${from})`,
 			to: `hue-rotate(${to})`,
@@ -383,6 +393,7 @@ export default class esQuery extends Set {
 		to = 1,
 		id = 'brightness',
 	} = {}) {
+		console.warn('`esQuery.filterBrightness()` is deprecated and will be removed');
 		return this.animateFilter({
 			from: `brightness(${from})`,
 			to: `brightness(${to})`,
@@ -410,6 +421,7 @@ export default class esQuery extends Set {
 		to = 1,
 		id = 'contrast',
 	} = {}) {
+		console.warn('`esQuery.filterContrast()` is deprecated and will be removed');
 		return this.animateFilter({
 			from: `contrast(${from})`,
 			to: `contrast(${to})`,
@@ -437,6 +449,7 @@ export default class esQuery extends Set {
 		to = 1,
 		id = 'saturate',
 	} = {}) {
+		console.warn('`esQuery.filterSaturate()` is deprecated and will be removed');
 		return this.animateFilter({
 			from: `saturate(${from})`,
 			to: `saturate(${to})`,
@@ -464,6 +477,7 @@ export default class esQuery extends Set {
 		to = 1,
 		id = 'saturate',
 	} = {}) {
+		console.warn('`esQuery.filerOpacity()` is deprecated and will be removed');
 		return this.animateFilter({
 			from: `opacity(${from})`,
 			to: `opacity(${to})`,
@@ -491,6 +505,7 @@ export default class esQuery extends Set {
 		to = 1,
 		id = 'sepia',
 	} = {}) {
+		console.warn('`esQuery.filterSepia()` is deprecated and will be removed');
 		return this.animateFilter({
 			from: `sepia(${from})`,
 			to: `sepia(${to})`,
@@ -812,6 +827,7 @@ export default class esQuery extends Set {
 	 * @deprecated [will be removed in v3.0.0]
 	 */
 	async loadHTML(href) {
+		console.warn('`esQuery.loadHTML()` is deprecated and will be removed');
 		const url = new URL(href, location.origin);
 		const resp = await fetch(url);
 
@@ -1182,7 +1198,7 @@ export default class esQuery extends Set {
 		return this.on('pagehide', callback, ...args);
 	}
 
-	async watch(watching, options = [], attributeFilter = []) {
+	async mutate(watching, options = [], attributeFilter = []) {
 		/*https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver*/
 		const watcher = new MutationObserver(mutations => {
 			mutations.forEach(mutation => watching[mutation.type].call(mutation));
@@ -1193,6 +1209,11 @@ export default class esQuery extends Set {
 		}, { attributeFilter });
 		this.forEach(el => watcher.observe(el, obs));
 		return this;
+	}
+
+	async watch(...args) {
+		console.warn('`esQuery.watch()` is deprecated, please use `esQuery.mutate()` instead');
+		return await this.mutate(...args);
 	}
 
 	/**
@@ -1211,18 +1232,34 @@ export default class esQuery extends Set {
 		return this;
 	}
 
-	async attr(attrs = {}) {
-		attr(this, attrs);
+	async attr(...args) {
+		attr(this, ...args);
 		return this;
 	}
 
-	async css(props = {}, { priority = undefined } = {}) {
-		css(this, props, { priority });
+	async css(...args) {
+		css(this, ...args);
 		return this;
 	}
 
-	async data(props = {}) {
-		data(this, props);
+	async data(...args) {
+		data(this, ...args);
 		return this;
+	}
+
+	static mediaQuery(query) {
+		return mediaQuery(query);
+	}
+
+	static async getLocation(...args) {
+		return await getLocation(...args);
+	}
+
+	static get loaded() {
+		return loaded();
+	}
+
+	static get ready() {
+		return ready();
 	}
 }

--- a/json_response.js
+++ b/json_response.js
@@ -1,4 +1,5 @@
-import {notify, $} from './functions.js';
+import { $ } from './functions.js';
+import { notify } from './deprecatedFunctions.js';
 
 export default async function handleJSON(json) {
 	if(typeof json === 'string') {

--- a/mutations.js
+++ b/mutations.js
@@ -1,6 +1,6 @@
 import * as handlers from './dataHandlers.js';
-import {$} from './functions.js';
-import {clickHandler} from './actions.js';
+import { $ } from './functions.js';
+import { clickHandler } from './actions.js';
 let observer = null;
 
 if (IntersectionObserver instanceof Function) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "std-js",
-  "version": "2.5.4",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "std-js",
-  "version": "2.6.0",
+  "version": "2.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -490,12 +490,6 @@
           "dev": true
         }
       }
-    },
-    "eslint-plugin-async-await": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-async-await/-/eslint-plugin-async-await-0.0.0.tgz",
-      "integrity": "sha1-DyrhejgUeAY11I8kCd+eN4mMoJ8=",
-      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "std-js",
-  "version": "2.5.4",
+  "version": "2.6.4",
   "description": "A JavaScript library for making front-end development sane!",
   "config": {
     "serve": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   },
   "devDependencies": {
     "eslint": "^7.3.1",
-    "eslint-plugin-async-await": "0.0.0",
     "htmlhint": "^0.14.1",
     "http-server": "^0.12.3"
   },

--- a/polyfills.js
+++ b/polyfills.js
@@ -1,5 +1,5 @@
 import * as classes from './polyfills/allClasses.js';
-import dePrefix from './deprefixer.js';
+import './deprefixer.js';
 
 // function checkFunction(functionName, functionObj) {
 // 	if ((functionObj instanceof Function) && ! (functionName in window)) {
@@ -39,7 +39,6 @@ function checkClass(className, classObj) {
 	}
 }
 export default function() {
-	dePrefix();
 	for (let shim in classes) {
 		try {
 			checkClass(shim, classes[shim]);

--- a/popstate.js
+++ b/popstate.js
@@ -1,5 +1,5 @@
 import handleJSON from './json_response.js';
-import {parseResponse, reportError} from './functions.js';
+import { parseResponse, reportError } from './functions.js';
 
 function popStateHandler() {
 	fetch(location).then(parseResponse).then(handleJSON).catch(reportError);

--- a/supports.js
+++ b/supports.js
@@ -132,12 +132,11 @@ export function supports(type) {
 		return false;
 	}
 }
+
 export function supportsAsClasses(...feats) {
-	if (feats instanceof Array) {
-		feats.forEach(feat => {
-			supports(feat)
-				? document.documentElement.classList.add(feat)
-				: document.documentElement.classList.add(`no-${feat}`);
-		});
-	}
+	feats.forEach(feat => {
+		supports(feat)
+			? document.documentElement.classList.add(feat)
+			: document.documentElement.classList.add(`no-${feat}`);
+	});
 }

--- a/test/index.css
+++ b/test/index.css
@@ -5,6 +5,7 @@
 @import url("https://cdn.kernvalley.us/css/core-css/class-rules.css");
 @import url("https://cdn.kernvalley.us/css/core-css/scrollbar.css");
 @import url("https://cdn.kernvalley.us/css/core-css/forms.css");
+@import url("https://cdn.kernvalley.us/css/core-css/animations.css");
 @import url("https://cdn.kernvalley.us/css/core-css/layout/default/index.css");
 @import url("https://cdn.kernvalley.us/css/core-css/theme/properties.css");
 @import url("https://cdn.kernvalley.us/css/core-css/theme/adwaita/index.css");

--- a/test/index.js
+++ b/test/index.js
@@ -1,16 +1,22 @@
 import '../shims.js';
 import '../deprefixer.js';
 import { loadHandler } from './funcs.js';
-import { $, ready } from '../functions.js';
+import { $ } from '../functions.js';
 // import kbdShortcuts from '../kbd_shortcuts.js';
 import { loadScript } from '../loader.js';
 import * as handlers from '../data-handlers.js';
 
-document.documentElement.classList.toggle('no-dialog', document.createElement('dialog') instanceof HTMLUnknownElement);
+$(document.documentElement, {
+	'no-dialog': document.createElement('dialog') instanceof HTMLUnknownElement,
+	'no-details': document.createElement('details') instanceof HTMLUnknownElement,
+	'js': true,
+	'no-js': false,
+	'no-custom-elements': 'customElements' in window,
+});
 
 window.$ = $;
 
-ready().then(async () => {
+$.ready.then(async () => {
 	const loads = [
 		loadScript('https://cdn.polyfill.io/v3/polyfill.min.js'),
 	];

--- a/wysiwyg.js
+++ b/wysiwyg.js
@@ -1,4 +1,4 @@
-import {query as $} from './functions.js';
+import { query as $ } from './functions.js';
 
 function getSelectedElement(matching = '[contenteditable="true"] *') {
 	let selected = getSelection().anchorNode;


### PR DESCRIPTION
### Added
- Add `ready`, `loaded`, `mediaQuery`, & `getLocation` static methods to `esQuery`

### Changed
- Move deprecated function in `functions.js` to separate script
- Set `esQuery` static methods on the `$` function when exporting
- Rename `wait()` to `sleep()` and alias old function with warning
- Misc. updates to reuse functions instead of repeating them
- Update linting & dependencies