### PR TITLE
New HTTP function to return a `File` from a `Request`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Function for opening windows/popups
 - Function to get files from URLs (using `Content-Type` header)
 - Functions for `fetch`ing `<link>`s (useful for preloads & manifests)
+- Add function for async submitting of forms
 
 ## [v2.6.1] - 2020-12-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Function for opening windows/popups
+- Function to get files from URLs (using `Content-Type` header)
 - Functions for `fetch`ing `<link>`s (useful for preloads & manifests)
 
 ## [v2.6.1] - 2020-12-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Function for opening windows/popups
+- Functions for `fetch`ing `<link>`s (useful for preloads & manifests)
 
 ## [v2.6.1] - 2020-12-18
 

--- a/http.js
+++ b/http.js
@@ -218,6 +218,29 @@ export async function getFile(url, {
 	}
 }
 
+export async function submitForm(form) {
+	if (typeof form === 'string') {
+		return await submitForm(document.forms[form]);
+	} else if (form instanceof Event) {
+		form.preventDefault();
+		return await submitForm(form.target);
+	} else if (form instanceof HTMLFormElement) {
+		switch (form.method.toLowerCase()) {
+			case 'get':
+				return GET(form.action, { body: new FormData(form) });
+
+			case 'post':
+				return POST(form.action, { body: new FormData(form) });
+
+			case 'delete':
+				return DELETE(form.action, { body: new FormData(form) });
+
+			default:
+				throw new Error(`Unsupported method: ${form.method}`);
+		}
+	}
+}
+
 export async function getManifest(timeout = null) {
 	const resp = await getLink('link[rel="manifest"][href]', timeout);
 	return await resp.json();

--- a/http.js
+++ b/http.js
@@ -218,6 +218,37 @@ export async function getFile(url, {
 	}
 }
 
+export async function getManifest(timeout = null) {
+	const resp = await getLink('link[rel="manifest"][href]', timeout);
+	return await resp.json();
+}
+
+export async function getLink(link, timeout = null) {
+	if (typeof link === 'string') {
+		return await getLink(document.querySelector(link));
+	} else if (! (link instanceof HTMLLinkElement)) {
+		throw new Error('Expected a <link>');
+	} else if (link.href.length === 0) {
+		throw new Error('Missing `href` on <link>');
+	} else {
+		const { href, integrity, type, referrerPolicy } = link;
+
+		let credentials;
+		const mode = ('crossOrigin' in link) ? 'cors' : 'no-cors';
+		const headers = new Headers();
+
+		if (mode === 'cors') {
+			credentials = link.crossOrigin === 'use-credentials' ? 'include' : 'omit';
+		}
+
+		if (typeof type === 'string') {
+			headers.set('Accept', type);
+		}
+
+		return await GET(href, { mode, credentials, headers, integrity, referrerPolicy, timeout });
+	}
+}
+
 export async function postHTML(url, {
 	body = undefined,
 	mode = 'cors',

--- a/http.js
+++ b/http.js
@@ -1,5 +1,22 @@
 import { parseHTML } from './functions.js';
 
+function filename(src) {
+	if (typeof src === 'string') {
+		const path = src.split('/');
+		return path[path.length - 1];
+	} else {
+		return '';
+	}
+}
+
+function getType({ headers }) {
+	if (headers instanceof Headers && headers.has('Content-Type')) {
+		return headers.get('Content-Type').split(';')[0];
+	} else {
+		return null;
+	}
+}
+
 export async function GET(url, {
 	body = undefined,
 	mode = 'cors',
@@ -170,6 +187,35 @@ export async function getJSON(url, {
 		cache, redirect, integrity, keepalive, signal, timeout });
 
 	return await resp.json();
+}
+
+export async function getFile(url, {
+	name = null,
+	body = undefined,
+	mode = 'cors',
+	cache = 'default',
+	credentials = 'omit',
+	redirect = 'follow',
+	referrerPolicy = 'no-referrer',
+	headers = new Headers(),
+	integrity = undefined,
+	keepalive = undefined,
+	signal = undefined,
+	timeout = null,
+} = {}) {
+	if (typeof name !== 'string') {
+		name = filename(url);
+	}
+
+	const resp = await GET(url, { body, mode, credentials, referrerPolicy, headers,
+		cache, redirect, integrity, keepalive, signal, timeout });
+
+	if (resp.ok) {
+		const type = getType(resp);
+		return new File([await resp.blob()], name, { type });
+	} else {
+		throw new Error(`Error fetching ${name}`);
+	}
 }
 
 export async function postHTML(url, {


### PR DESCRIPTION
- Function to get files from URLs (using `Content-Type` header)
- Functions for `fetch`ing `<link>`s (useful for preloads & manifests)

```js
import { getFile, getLink } from '/http.js';
import { save } from '/filesystem.js';

getFile('/img.jpg', { accept: 'image/jpeg' }).then(save);
getLink('link[rel="manifest"]').then(({ name, icons }) => /* ... */);
```