### PR TITLE
Update `loaded()` and `ready()` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Async helper function `statusDialog()` for creating `<dialog>`s
 - `date-consts.js` module exporting 0-indexed array of days and months
 
+### Fixed
+- Simplified `ready()` and `loaded()` to be more direct and not check for custom elements defined
+
 ## [v2.6.1] - 2020-12-18
 
 ### Added

--- a/functions.js
+++ b/functions.js
@@ -548,26 +548,16 @@ export async function wait(ms) {
 	await sleep(ms);
 }
 
-export async function ready(...requires) {
+export async function ready() {
 	if (document.readyState === 'loading') {
-		await Promise.allSettled([
-			when(document, 'DOMContentLoaded'),
-			defined(...requires),
-		]);
-	} else {
-		await defined(...requires);
+		await new Promise(r => document.addEventListener('DOMContentLoaded', r, { once: true }));
 	}
 
 }
 
-export async function loaded(...requires) {
+export async function loaded() {
 	if (document.readyState !== 'complete') {
-		await Promise.allSettled([
-			when(window, 'load'),
-			defined(...requires),
-		]);
-	} else {
-		await defined(...requires);
+		await new Promise(r => window.addEventListener('load', r, { once: true }));
 	}
 }
 


### PR DESCRIPTION
Simplified `ready()` and `loaded()` to be more direct and not check for custom elements defined
