### PR TITLE
Implement `KeyValueStore`  class using `indexedDB`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create `ShoppingCart` class utilizing `IndexedDB`
 - Add `EventObserver` class, which is a generator `yield`ing dispatched events
 - Misc. `dom.js` enhancements
+- Implement `indexedDB` version of basic key/value store
+- Shim for `globalThis`
 
 ## [v2.6.2] - 2021-02-15
 

--- a/KeyValueStore.js
+++ b/KeyValueStore.js
@@ -124,7 +124,17 @@ export class KeyValueStore extends EventTarget {
 
 	async has(...keys) {
 		const stored = await this.keys();
-		return keys.every(key => stored.has(key));
+
+		switch(keys.length) {
+			case 0:
+				return true;
+
+			case 1:
+				return stored.includes(keys[0]);
+
+			default:
+				return keys.every(key => stored.includes(key));
+		}
 	}
 
 	async delete(...keys) {

--- a/KeyValueStore.js
+++ b/KeyValueStore.js
@@ -1,0 +1,162 @@
+import { when } from './dom.js';
+
+const protectedData = new WeakMap();
+
+function setData(obj, data) {
+	if (protectedData.has(obj)) {
+		protectedData.set(obj, {...protectedData.get(obj), ...data });
+	} else {
+		protectedData.set(obj, data);
+	}
+}
+
+function getData(obj, key, defaultValue) {
+	if (! protectedData.has(obj)) {
+		return defaultValue;
+	} else if (typeof key === 'string') {
+		return protectedData.get(obj)[key] || defaultValue;
+	} else {
+		return protectedData.get(obj);
+	}
+}
+
+async function getObjectStore(obj, { mode = 'readonly' } = {}) {
+	await obj.connected;
+	const { store, db } = getData(obj);
+	const trans = db.transaction([store], mode);
+	return trans.objectStore(store);
+}
+
+async function doAsyncAction(obj, { successEvent = 'success', errorEvent = 'error' } = {}) {
+	if (! (obj instanceof EventTarget)) {
+		console.info({ obj });
+		throw new TypeError('doAsyncAction() required obj to be an instance of EventTarget');
+	} else {
+		return new Promise((resolve, reject) => {
+			obj.addEventListener(successEvent, resolve);
+			obj.addEventListener(errorEvent, reject);
+		});
+	}
+}
+
+export class KeyValueStore extends EventTarget {
+	constructor({ name = KeyValueStore.dbName, store = KeyValueStore.storeName, version = 1 } = {}) {
+		super();
+
+		if (! KeyValueStore.supported) {
+			throw new DOMException('IndexedDB is not supported in this browser');
+		} else {
+			const req = indexedDB.open(name, version);
+
+			req.addEventListener('upgradeneeded', async ({ target: { result: db }}) => {
+				// @TODO handle migrating between versions
+				try {
+					const oStore = db.createObjectStore(store, { keyPath: 'key' });
+					console.log({ db, oStore });
+					oStore.createIndex('value', 'value', { unique: false });
+					oStore.createIndex('updated', 'updated', { unique: false });
+				} catch(err) {
+					console.error(err);
+				}
+			});
+
+			doAsyncAction(req).then(({ target: { result: db }}) => {
+				setData(this, { db, store, version });
+				this.dispatchEvent(new Event('connected'));
+			}).catch(err => {
+				throw err;
+			});
+		}
+	}
+
+	get connected() {
+		if (protectedData.has(this)) {
+			return Promise.resolve(this);
+		} else {
+			return when([this], 'connected').then(() => this);
+		}
+	}
+
+	async get(key) {
+		await this.connected;
+		const store = await getObjectStore(this, { mode: 'readonly' });
+
+		return await doAsyncAction(store.get(key))
+			.then(({ target: { result = { value: undefined }}}) =>result.value);
+	}
+
+	async getAll(...keys) {
+		await this.connected;
+		const store = await getObjectStore(this, { mode: 'readonly' });
+
+		return Promise.all(keys.map(async key => {
+			const { target: { result }} = await doAsyncAction(store.get(key));
+			if (typeof result === 'undefined') {
+				return { key, value: undefined, updated: 0 };
+			} else {
+				return result;
+			}
+		}));
+	}
+
+	async set(key, value) {
+		await this.connected;
+		const store = await getObjectStore(this, { mode: 'readwrite' });
+		await doAsyncAction(store.put({ key, value, updated: Date.now() }));
+		this.dispatchEvent(new CustomEvent('update', { detail: { key, value }}));
+	}
+
+	async setAll(obj) {
+		if (! (obj instanceof Object)) {
+			throw new TypeError('setAll() expects an Object');
+		} else {
+			await this.connected;
+			const store = await getObjectStore(this, { mode: 'readwrite' });
+			const entries = Object.entries(obj);
+
+			await Promise.all(entries.map(async ([key, value]) => {
+				await doAsyncAction(store.put({ key, value, updated: Date.now() }));
+			}));
+
+			this.dispatchEvent(new CustomEvent('update', { detail: obj }));
+		}
+	}
+
+	async delete(...keys) {
+		try {
+			await this.connected;
+			const store = await getObjectStore(this, { mode: 'readwrite' });
+			await Promise.all(keys.map(async key => await doAsyncAction(store.delete(key))));
+			this.dispatchEvent(new CustomEvent('update', {
+				detail: Object.fromEntries(keys.map(key => [key, undefined])),
+			}));
+			return true;
+		} catch(err) {
+			console.error(err);
+			return false;
+		}
+	}
+
+	async reset() {
+		try {
+			const store = await getObjectStore(this, { mode: 'readwrite' });
+			await doAsyncAction(store.clear());
+			return true;
+		} catch(err) {
+			console.error(err);
+			return false;
+		}
+	}
+
+	static get dbName() {
+		return 'key-value-store';
+	}
+
+	static get storeName() {
+		return 'key-value';
+	}
+
+	static get supported() {
+		return 'indexedDB' in window;
+	}
+}

--- a/KeyValueStore.js
+++ b/KeyValueStore.js
@@ -122,6 +122,11 @@ export class KeyValueStore extends EventTarget {
 		}
 	}
 
+	async has(...keys) {
+		const stored = await this.keys();
+		return keys.every(key => stored.has(key));
+	}
+
 	async delete(...keys) {
 		try {
 			await this.connected;
@@ -135,6 +140,13 @@ export class KeyValueStore extends EventTarget {
 			console.error(err);
 			return false;
 		}
+	}
+
+	async keys({ query, count } = {}) {
+		await this.connected;
+		const store = await getObjectStore(this, { mode: 'readonly' });
+		return await doAsyncAction(store.getAllKeys(query, count))
+			.then(({ target: { result = [] }}) => result);
 	}
 
 	async reset() {

--- a/KeyValueStore.js
+++ b/KeyValueStore.js
@@ -189,6 +189,24 @@ export class KeyValueStore extends EventTarget {
 			.then(({ target: { result = [] }}) => result);
 	}
 
+	async values() {
+		const store = await getObjectStore(this, { mode: 'readonly' });
+
+		return await doAsyncAction(store.getAll())
+			.then(({ target: { result = [] }}) => {
+				return result.map(({ value }) => value);
+			});
+	}
+
+	async entries() {
+		const store = await getObjectStore(this, { mode: 'readonly' });
+
+		return await doAsyncAction(store.getAll())
+			.then(({ target: { result = [] }}) => {
+				return result.map(({ key, value }) => [key, value]);
+			});
+	}
+
 	/**
 	 * NOTE: `.json()` cannot handle `File`s, etc.
 	 */

--- a/ShoppingCart.js
+++ b/ShoppingCart.js
@@ -41,7 +41,6 @@ export const fields = [{
 
 async function doAsyncAction(obj, { successEvent = 'success', errorEvent = 'error' } = {}) {
 	if (! (obj instanceof EventTarget)) {
-		console.info({ obj });
 		throw new TypeError('doAsyncAction() required obj to be an instance of EventTarget');
 	} else {
 		return new Promise((resolve, reject) => {

--- a/shims.js
+++ b/shims.js
@@ -1,5 +1,16 @@
 import CookieStore from  './CookieStore.js';
 
+if (typeof globalThis === 'undefined') {
+	if (typeof self !== 'undefined') {
+		self.globalThis = self;
+	} else if (typeof window !== 'undefined') {
+		window.globalThis = window;
+	} else if (typeof global !== 'undefined') {
+		/* global global: true */
+		global.globalThis = global;
+	}
+}
+
 if (! (Element.prototype.getAttributeNames instanceof Function)) {
 	Element.prototype.getAttributeNames = function() {
 		return Array.from(this.attributes).map(({ name }) => name);


### PR DESCRIPTION
Also adds shim for `globalThis`

## `KeyValueStore` usage example
```js
import { KeyValueStore } from './KeyValueStore.js';

const store = new KeyValueStore({ name: 'db', store: 'items', version: 2 });
await store.setAll({ str: 'Hello World!', num: 42, file: new File([''], name: 'empty.txt', { type: 'text/plain' }) });
await store.keys(); // ['str', 'num', 'file']
await store.has('str', 'num'); // true
await store.get('num'); // 42
await store.reset();
await store.close();
```