### PR TITLE
Add shim for `AbortSignal` handling in `addEventListener()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Misc. `dom.js` enhancements
 - Implement `indexedDB` version of basic key/value store
 - Shim for `globalThis`
+- Shim for `addEventListener()` `signal` handling
+- Event feature detection (`signal`, `once`, etc.)
 
 ## [v2.6.2] - 2021-02-15
 

--- a/dom.js
+++ b/dom.js
@@ -418,8 +418,9 @@ export async function when(target, event, {
 	once = true,
 	capture = true,
 	passive = true,
+	signal,
 } = {}) {
-	await new Promise(resolve => on(target, event, resolve, { once, capture, passive }));
+	await new Promise(resolve => on(target, event, resolve, { once, capture, passive, signal }));
 }
 
 export async function ready() {


### PR DESCRIPTION
- Event feature detection (`signal`, `once`, etc.)
- Use `removeEventListener` as fallback if `signal` not supported