### PR TITLE
Improve `AbortSignal` handling and add `Deferred` (Promise-like) class

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
         "no-prototype-builtins": 0
     },
     "globals": {
-      "cookieStore": "readonly"
+      "cookieStore": "readonly",
+      "globalThis": "readonly"
     }
 }

--- a/Deferred.js
+++ b/Deferred.js
@@ -1,0 +1,225 @@
+const protectedData = new WeakMap();
+
+function getData(def, key) {
+	const data = protectedData.get(def);
+
+	if (typeof key === 'string') {
+		return data[key];
+	} else {
+		return data;
+	}
+}
+
+function setData(def, data) {
+	if (protectedData.has(def)) {
+		protectedData.set(def, {...protectedData.get(def), ...data });
+	} else {
+		protectedData.set(def, data);
+	}
+}
+
+export class Deferred extends EventTarget {
+	constructor(success, fail) {
+		super();
+		const obj = {};
+
+		obj.promise = new Promise((resolve, reject) => {
+			obj.resolve = resolve;
+			obj.reject = reject;
+		});
+
+		setData(this, obj);
+
+		if (success instanceof Function) {
+			this.then(success);
+		}
+
+		if (fail instanceof Function) {
+			this.catch(fail);
+		}
+	}
+
+	get fullfilled() {
+		return this.state !== 'pending';
+	}
+
+	get error() {
+		return getData(this, 'error');
+	}
+
+	get pending() {
+		return this.state === 'pending';
+	}
+
+	get promise() {
+		switch(this.state) {
+			case 'done':
+				return Promise.resolve(this.result);
+
+			case 'error':
+				return Promise.reject(this.error);
+
+			default:
+				return getData(this, 'promise');
+		}
+	}
+
+	get result() {
+		return getData(this, 'result');
+	}
+
+	get state() {
+		const { result, error } = getData(this);
+
+		if (typeof result !== 'undefined') {
+			return 'done';
+		} else if (typeof error !== 'undefined') {
+			return 'error';
+		} else {
+			return 'pending';
+		}
+	}
+
+	get whenFullfilled() {
+		if (this.pending) {
+			return this.when('statechange').then(() => this);
+		} else {
+			return Promise.resolve(this);
+		}
+	}
+
+	resolve(result) {
+		if (this.state !== 'pending') {
+			throw new DOMException('Already resolved');
+		} else if (typeof result === 'undefined') {
+			throw new TypeError('Cannot resolve with undefined');
+		} else {
+			const resolve = getData(this, 'resolve');
+			setData(this, { result });
+			resolve(result);
+			this.dispatchEvent(new CustomEvent('statechange', { detail: 'done' }));
+			this.dispatchEvent(new CustomEvent('done', { detail: result }));
+		}
+	}
+
+	reject(error) {
+		if (this.state !== 'pending') {
+			throw new DOMException('Already resolved');
+		} else if (typeof error === 'undefined') {
+			throw new TypeError('Cannot reject with undefined');
+		} else {
+			const reject = getData(this, 'reject');
+			setData(this, { error });
+			reject(error);
+			this.dispatchEvent(new CustomEvent('statechange', { detail: 'error' }));
+			this.dispatchEvent(new CustomEvent('error', { detail: error }));
+		}
+	}
+
+	async then(success, fail) {
+		return this.promise.then(success, fail);
+	}
+
+	async catch(fail) {
+		return this.promise.catch(fail);
+	}
+
+	async finally(callback) {
+		return this.promise.finally(callback);
+	}
+
+	on(event, callback, opts) {
+		this.addEventListener(event, callback, opts);
+	}
+
+	off(event, callback, opts) {
+		this.removeEventListener(event, callback, opts);
+	}
+
+	once(event, callback, { signal } = {}) {
+		this.on(event, callback, { once: true, signal });
+	}
+
+	async when(event, { signal } = {}) {
+		return new Promise(resolve => this.once(event, ({ detail }) => resolve(detail), { signal }));
+	}
+
+	static fromPromise(promise) {
+		if (! (promise instanceof Promise)) {
+			throw new TypeError('Must be a Promise');
+		} else {
+			const def = new Deferred();
+			promise.then(result => def.resolve(result));
+			promise.catch(err => def.reject(err));
+			return def;
+		}
+	}
+
+	static async resolve(result) {
+		const def = new Deferred();
+		def.resolve(result);
+		return def;
+	}
+
+	static async reject(err) {
+		const def = new Deferred();
+		def.reject(err);
+		return def;
+	}
+
+	static async race(defs) {
+		if (Array.isArray(defs)) {
+			return await Promise.race(defs.map(def => {
+				if (def instanceof Deferred) {
+					return def.whenFullfilled;
+				} else if (def instanceof Promise) {
+					return Deferred.fromPromise(def).whenFullfilled;
+				} else {
+					return Deferred.resolve(def);
+				}
+			}));
+		}
+	}
+
+	static async all(defs) {
+		if (Array.isArray(defs)) {
+			return await Promise.all(defs.map(def => {
+				if (def instanceof Deferred) {
+					return def.whenFullfilled;
+				} else if (def instanceof Promise) {
+					return Deferred.fromPromise(def).whenFullfilled;
+				} else {
+					return Deferred.resolve(def);
+				}
+			}));
+		}
+	}
+
+	static async allSettled(defs) {
+		if (Array.isArray(defs)) {
+			return await Promise.allSettled(defs.map(def => {
+				if (def instanceof Deferred) {
+					return def.whenFullfilled;
+				} else if (def instanceof Promise) {
+					return Deferred.fromPromise(def).whenFullfilled;
+				} else {
+					return Deferred.resolve(def);
+				}
+			}));
+		}
+	}
+
+	static async any(defs) {
+		if (Array.isArray(defs)) {
+			return await Promise.any(defs.map(def => {
+				if (def instanceof Deferred) {
+					return def.whenFullfilled;
+				} else if (def instanceof Promise) {
+					return Deferred.fromPromise(def).whenFullfilled;
+				} else {
+					return Deferred.resolve(def);
+				}
+			}));
+		}
+	}
+}

--- a/dom.js
+++ b/dom.js
@@ -40,7 +40,10 @@ function getEventFeatures() {
 
 export const eventFeatures = getEventFeatures();
 
-function addListener(targets, events, callback, { capture, once, passive, signal } = {}) {
+export function addListener(targets, events, callback, { capture, once, passive, signal } = {}) {
+	if (! Array.isArray(targets)) {
+		targets = Array.of(targets);
+	}
 	targets.forEach(target => {
 		events.forEach(event => target.addEventListener(event, callback, { capture, once, passive, signal }));
 	});

--- a/dom.js
+++ b/dom.js
@@ -1,6 +1,7 @@
 function getEventFeatures() {
 	const el = document.createElement('div');
 	const eventFeatures = {
+		nativeSignal: 'AbortController' in window && AbortController.prototype.hasOwnProperty('signal'),
 		signal: false,
 		passive: false,
 		capture: false,
@@ -27,8 +28,12 @@ function getEventFeatures() {
 		},
 	};
 
-	el.addEventListener('click', null, options);
-	el.removeEventListener('click', null, options);
+	try {
+		el.addEventListener('click', null, options);
+		el.removeEventListener('click', null, options);
+	} catch(err) {
+		console.error(err);
+	}
 
 	return Object.seal(eventFeatures);
 }
@@ -40,7 +45,7 @@ function addListener(targets, events, callback, { capture, once, passive, signal
 		events.forEach(event => target.addEventListener(event, callback, { capture, once, passive, signal }));
 	});
 
-	if ('AbortSignal' in window && 'signal' instanceof AbortSignal && eventFeatures.signal === false) {
+	if ('AbortSignal' in window && 'signal' instanceof AbortSignal &&( eventFeatures.signal === false || eventFeatures.nativeSignal === false)) {
 		signal.addEventListener('abort', () => {
 			events.forEach(event => {
 				targets.forEach(target => target.removeEventListener(event, callback, { capture, once, passive, signal }));
@@ -495,4 +500,19 @@ export function mutate(what, callback, opts = {}) {
 
 export function supportsElement(...tags) {
 	return ! tags.some(tag => document.createElement(tag) instanceof HTMLUnknownElement);
+}
+
+export async function abortablePromise(promise, signal) {
+	return await new Promise((resolve, reject) => {
+		if (! (promise instanceof Promise)) {
+			reject(new TypeError('promise must be a Promise'));
+		} else if (! (signal instanceof AbortSignal)) {
+			reject(new TypeError('signal must be an AbortSignal'));
+		} else if (signal.aborted) {
+			reject(new DOMException('The operation was aborted.'));
+		} else {
+			promise.then(resolve).catch(reject);
+			signal.addEventListener('abort', () => reject(new DOMException('The operation was aborted.')), { once: true });
+		}
+	});
 }

--- a/esQuery.js
+++ b/esQuery.js
@@ -898,7 +898,7 @@ export default class esQuery extends Set {
 				}
 			}));
 		} else {
-			this.forEach(node => [...node.children].forEach(child => child.remove()));
+			this.forEach(node => node.replaceChildren());
 		}
 		return this;
 	}

--- a/http.js
+++ b/http.js
@@ -1,4 +1,5 @@
 import { parseHTML, signalAborted, eventFeatures } from './dom.js';
+import { Deferred } from './Deferred.js';
 
 function filename(src) {
 	if (typeof src === 'string') {
@@ -14,6 +15,14 @@ function getType({ headers }) {
 		return headers.get('Content-Type').split(';')[0];
 	} else {
 		return null;
+	}
+}
+
+export async function fetch(url, opts) {
+	if ('AbortSignal' in window && opts.signal instanceof AbortSignal && eventFeatures.nativeSignal === false) {
+		return await Promise.race([window.fetch(url), signalAborted(opts.signal)]);
+	} else {
+		return await window.fetch(url, opts);
 	}
 }
 
@@ -46,14 +55,8 @@ export async function GET(url, {
 		signal = signal.signal;
 	}
 
-	const resp = fetch(url, { method: 'GET', mode, credentials, referrerPolicy, headers,
+	return await fetch(url, { method: 'GET', mode, credentials, referrerPolicy, headers,
 		cache, redirect, integrity, keepalive, signal });
-
-	if (typeof signal !== 'undefined' && eventFeatures.nativeSignal === false) {
-		return await Promise.race([resp, signalAborted(signal)]);
-	} else {
-		return await resp;
-	}
 
 }
 
@@ -94,14 +97,8 @@ export async function POST(url, {
 		signal = signal.signal;
 	}
 
-	const resp = fetch(url, { method: 'POST', body, mode, credentials, referrerPolicy, headers,
+	return await fetch(url, { method: 'POST', body, mode, credentials, referrerPolicy, headers,
 		cache, redirect, integrity, keepalive, signal });
-
-	if (typeof signal !== 'undefined' && eventFeatures.nativeSignal === false) {
-		return await Promise.race([resp, signalAborted(signal)]);
-	} else {
-		return await resp;
-	}
 }
 
 export async function DELETE(url, {
@@ -133,14 +130,8 @@ export async function DELETE(url, {
 		signal = signal.signal;
 	}
 
-	const resp = fetch(url, { method: 'DELETE', mode, credentials, referrerPolicy, headers,
+	return await fetch(url, { method: 'DELETE', mode, credentials, referrerPolicy, headers,
 		cache, redirect, integrity, keepalive, signal });
-
-	if (typeof signal !== 'undefined' && eventFeatures.nativeSignal === false) {
-		return await Promise.race([resp, signalAborted(signal)]);
-	} else {
-		return await resp;
-	}
 }
 
 export async function getHTML(url, {

--- a/http.js
+++ b/http.js
@@ -1,4 +1,4 @@
-import { parseHTML } from './dom.js';
+import { parseHTML, signalAborted, eventFeatures } from './dom.js';
 
 function filename(src) {
 	if (typeof src === 'string') {
@@ -46,8 +46,15 @@ export async function GET(url, {
 		signal = signal.signal;
 	}
 
-	return await fetch(url, { method: 'GET', mode, credentials, referrerPolicy, headers,
+	const resp = fetch(url, { method: 'GET', mode, credentials, referrerPolicy, headers,
 		cache, redirect, integrity, keepalive, signal });
+
+	if (typeof signal !== 'undefined' && eventFeatures.nativeSignal === false) {
+		return await Promise.race([resp, signalAborted(signal)]);
+	} else {
+		return await resp;
+	}
+
 }
 
 export async function POST(url, {
@@ -87,13 +94,13 @@ export async function POST(url, {
 		signal = signal.signal;
 	}
 
-	const resp = await fetch(url, { method: 'POST', body, mode, credentials, referrerPolicy, headers,
+	const resp = fetch(url, { method: 'POST', body, mode, credentials, referrerPolicy, headers,
 		cache, redirect, integrity, keepalive, signal });
 
-	if (resp.ok) {
-		return resp;
+	if (typeof signal !== 'undefined' && eventFeatures.nativeSignal === false) {
+		return await Promise.race([resp, signalAborted(signal)]);
 	} else {
-		throw new Error(`${resp.url} [${resp.status} ${resp.statusText}]`);
+		return await resp;
 	}
 }
 
@@ -126,8 +133,14 @@ export async function DELETE(url, {
 		signal = signal.signal;
 	}
 
-	return await fetch(url, { method: 'DELETE', mode, credentials, referrerPolicy, headers,
+	const resp = fetch(url, { method: 'DELETE', mode, credentials, referrerPolicy, headers,
 		cache, redirect, integrity, keepalive, signal });
+
+	if (typeof signal !== 'undefined' && eventFeatures.nativeSignal === false) {
+		return await Promise.race([resp, signalAborted(signal)]);
+	} else {
+		return await resp;
+	}
 }
 
 export async function getHTML(url, {

--- a/http.js
+++ b/http.js
@@ -1,5 +1,4 @@
 import { parseHTML, signalAborted, eventFeatures } from './dom.js';
-import { Deferred } from './Deferred.js';
 
 function filename(src) {
 	if (typeof src === 'string') {

--- a/shims.js
+++ b/shims.js
@@ -27,12 +27,16 @@ if (! ('AbortSignal' in window)) {
 
 	window.AbortController = class AbortController {
 		constructor() {
-			this.signal = new AbortSignal();
+			this._signal = new AbortSignal();
+		}
+
+		get signal() {
+			return this._signal;
 		}
 
 		abort() {
-			this.signal._aborted = true;
-			this.signal.dispatchEvent(new Event('abort'));
+			this._signal._aborted = true;
+			this._signal.dispatchEvent(new Event('abort'));
 		}
 	};
 }

--- a/shims.js
+++ b/shims.js
@@ -1,5 +1,42 @@
 import CookieStore from  './CookieStore.js';
 
+if (! ('EventTarget' in window)) {
+	window.EventTarget = class EventTarget extends HTMLUnknownElement {};
+}
+
+if (! ('AbortSignal' in window)) {
+	window.AbortError = class AbortError extends Error {};
+
+	window.AbortSignal = class AbortSignal extends EventTarget {
+		constructor() {
+			super();
+			this.onabort = null;
+			this._aborted = false;
+
+			this.addEventListener('abort', () => {
+				if (this.onabort instanceof Function) {
+					this.onabort();
+				}
+			});
+		}
+
+		get aborted() {
+			return this._aborted;
+		}
+	};
+
+	window.AbortController = class AbortController {
+		constructor() {
+			this.signal = new AbortSignal();
+		}
+
+		abort() {
+			this.signal._aborted = true;
+			this.signal.dispatchEvent(new Event('abort'));
+		}
+	};
+}
+
 if (typeof globalThis === 'undefined') {
 	if (typeof self !== 'undefined') {
 		self.globalThis = self;


### PR DESCRIPTION
- Add functions to reject `Promise`s using `signal`
- Improve usage of `AbortSignal` in event handlers & HTTP requests
- Implement `Promise`-like `Deferred` class