### PR TITLE
Add module for swapping out slotted content

### DIFF
--- a/slot-replacement.js
+++ b/slot-replacement.js
@@ -1,0 +1,32 @@
+function update(slot) {
+	slot.assignedElements().forEach(el => {
+		if (el instanceof HTMLTemplateElement) {
+			const frag = el.content;
+			[...frag.children].forEach(el => el.slot = slot.name);
+			el.replaceWith(frag);
+		}
+	});
+}
+
+function changeHandler() {
+	update(this);
+}
+
+export function slotReplacementHandler(shadow) {
+	shadow.querySelectorAll('slot[name]').forEach(slot => {
+		update(slot);
+		slot.addEventListener('slotchange', changeHandler);
+	});
+}
+
+
+customElements.define('test-el', class HTMLTestEl extends HTMLElement {
+	constructor() {
+		super();
+		const shadow = this.attachShadow({ mode: 'closed' });
+		const slot = document.createElement('slot');
+		slot.name = 'content';
+		shadow.append(slot);
+		slotReplacementHandler(shadow);
+	}
+});

--- a/slot-replacement.js
+++ b/slot-replacement.js
@@ -18,15 +18,3 @@ export function slotReplacementHandler(shadow) {
 		slot.addEventListener('slotchange', changeHandler);
 	});
 }
-
-
-customElements.define('test-el', class HTMLTestEl extends HTMLElement {
-	constructor() {
-		super();
-		const shadow = this.attachShadow({ mode: 'closed' });
-		const slot = document.createElement('slot');
-		slot.name = 'content';
-		shadow.append(slot);
-		slotReplacementHandler(shadow);
-	}
-});

--- a/slot-replacement.js
+++ b/slot-replacement.js
@@ -12,9 +12,20 @@ function changeHandler() {
 	update(this);
 }
 
-export function slotReplacementHandler(shadow) {
-	shadow.querySelectorAll('slot[name]').forEach(slot => {
-		update(slot);
-		slot.addEventListener('slotchange', changeHandler);
-	});
+export function slotReplacementHandler(shadow, ...slots) {
+	if (slots.length === 0) {
+		shadow.querySelectorAll('slot[name]').forEach(slot => {
+			update(slot);
+			slot.addEventListener('slotchange', changeHandler);
+		});
+	} else {
+		slots.forEach(name => {
+			const slot = shadow.querySelector(`slot[name="${name}"]`);
+
+			if (slot instanceof HTMLSlotElement) {
+				update(slot);
+				slot.addEventListener('slotchange', changeHandler);
+			}
+		});
+	}
 }


### PR DESCRIPTION
Setting `<template slot="foo">` on custom elements with `shadowRoot` can be very useful for treating slotted content as inert until the custom element and shadow have been created.