### PR TITLE
Refactor handling of `when()` and `signalAborted()`

### DIFF
--- a/events.js
+++ b/events.js
@@ -15,19 +15,19 @@ function getEventFeatures() {
 	const options = {
 		get passive() {
 			eventFeatures.passive = true;
-			return true;
+			return undefined;
 		},
 		get signal() {
 			eventFeatures.signal = true;
-			return new AbortController().signal;
+			return undefined;
 		},
 		get capture() {
 			eventFeatures.capture = true;
-			return true;
+			return undefined;
 		},
 		get once() {
 			eventFeatures.once = true;
-			return false;
+			return undefined;
 		},
 	};
 
@@ -56,7 +56,7 @@ export function addListener(targets, events, callback, { capture, once, passive,
 		events.forEach(event => target.addEventListener(event, callback, { capture, once, passive, signal }));
 	});
 
-	if (signal instanceof AbortSignal && (features.nativeSignal === false || features.signal === false)) {
+	if (signal instanceof AbortSignal && features.signal === false) {
 		signalAborted(signal).finally(() => {
 			removeListener(targets, events, callback, { capture, once, passive, signal });
 		});

--- a/http.js
+++ b/http.js
@@ -4,8 +4,7 @@ import { features as eventFeatures } from './events.js';
 
 function filename(src) {
 	if (typeof src === 'string') {
-		const path = src.split('/');
-		return path[path.length - 1];
+		return new URL(src, location.origin).pathname.split('/').at(-1);
 	} else {
 		return '';
 	}


### PR DESCRIPTION
Using `when([signal], ['abort'])` caused an infinite/recursive loop.

Resolves #304 