### PR TITLE
Update handling of sharing

### DIFF
--- a/data-share.js
+++ b/data-share.js
@@ -1,0 +1,39 @@
+export const SELECTOR = '[data-share-title], [data-share-text], [data-share-url]';
+
+export const SUPPORTED = navigator.share instanceof Function;
+
+export function hasShareAttrs(target) {
+	return target instanceof Element && target.matches(SELECTOR);
+}
+
+async function shareHandler() {
+	this.disabled = true;
+	const { shareTitle: title, shareText: text, shareUrl: url } = this.dataset;
+
+	try {
+		await navigator.share({ title, text, url });
+	} catch(err) {
+		console.error(err);
+	} finally {
+		this.disabled = false;
+	}
+}
+
+export function shareInit(target = document.body) {
+	if (typeof target === 'string') {
+		target = document.querySelector(target);
+	}
+
+	if (SUPPORTED && target instanceof Element) {
+		const targets = hasShareAttrs(target) ? [target] : [...target.querySelectorAll(SELECTOR)];
+
+		targets.forEach(el => {
+			el.addEventListener('click', shareHandler, { passive: true });
+			el.hidden = false;
+		});
+
+		return true;
+	} else {
+		return false;
+	}
+}

--- a/shims.js
+++ b/shims.js
@@ -198,7 +198,7 @@ if (! (navigator.canShare instanceof Function)) {
 		} else {
 			return [title, text, url].some(arg => typeof arg === 'string' && arg.length !== 0);
 		}
-	}
+	};
 }
 
 if (! (navigator.setAppBadge instanceof Function)) {

--- a/shims.js
+++ b/shims.js
@@ -187,6 +187,20 @@ if (! (Object.fromEntries instanceof Function)) {
 	};
 }
 
+if (! (navigator.canShare instanceof Function)) {
+	navigator.canShare = function({ title, text, url, files } = {}) {
+		if (! (navigator.share instanceof Function)) {
+			return false;
+		} else if (Array.isArray(files) && files.length !== 0) {
+			return false;
+		} else if ([title, text, url].every(arg => typeof arg === 'undefined')) {
+			return true;
+		} else {
+			return [title, text, url].some(arg => typeof arg === 'string' && arg.length !== 0);
+		}
+	}
+}
+
 if (! (navigator.setAppBadge instanceof Function)) {
 	navigator.setAppBadge = async (n) => {
 		if (! Number.isInteger(n)) {


### PR DESCRIPTION
Since Safari is an (unfortunately) common browser that does not support `<button is="share-button">`, provide a simple alternative using `data-share-*` attributes.

Also add `navigator.canShare()` to `shims.js`
