### PR TITLE
Add module to for optional chaining

### DIFF
--- a/chain.js
+++ b/chain.js
@@ -1,0 +1,24 @@
+export function unchain(str, { base = globalThis, defaultValue = undefined, expect = undefined } = {}) {
+	if (typeof str === 'string' && str.length !== 0) {
+		let result = base;
+
+		const found = str.split('.').every(seg => {
+			if (seg.length !== 0 && seg in result) {
+				result = result[seg];
+				return result != null;
+			} else {
+				return false;
+			}
+		});
+
+		if (! found) {
+			return defaultValue;
+		} else if (typeof expect === 'string') {
+			return typeof result === expect ? result : defaultValue;
+		} else {
+			return result;
+		}
+	} else {
+		return defaultValue;
+	}
+}


### PR DESCRIPTION
Useful until optional chaining is better supported.

### Instead of
`navigator?.connection?.type ?? 'unknown'`;

### Use
`unchain('connection.type', { defaultValue: 'unknown', base: navigator })`
