### PR TITLE
More refactoring of code

### DIFF
--- a/abort-shims.js
+++ b/abort-shims.js
@@ -1,12 +1,16 @@
 if (! ('AbortSignal' in globalThis)) {
-	const protectedData = new WeakMap();
+	const symbols = {
+		signal: Symbol('signal'),
+		aborted: Symbol('aborted'),
+	};
+
 	globalThis.AbortError = class AbortError extends Error {};
 
 	globalThis.AbortSignal = class AbortSignal extends EventTarget {
 		constructor() {
 			super();
 			this.onabort = null;
-			protectedData.set(this, { aborted: false });
+			this[symbols.aborted] = false;
 
 			this.addEventListener('abort', event => {
 				if (this.onabort instanceof Function) {
@@ -16,23 +20,40 @@ if (! ('AbortSignal' in globalThis)) {
 		}
 
 		get aborted() {
-			return protectedData.get(this).aborted;
+			return this[symbols.aborted];
+		}
+
+		static abort() {
+			const signal = new AbortSignal();
+			signal[symbols.aborted] = true;
+			return signal;
 		}
 	};
 
 	globalThis.AbortController = class AbortController {
 		constructor() {
-			protectedData.set(this, { signal: new AbortSignal() });
+			this[symbols.signal] = new AbortSignal();
 		}
 
 		get signal() {
-			return protectedData.get(this).signal;
+			return this[symbols.signal];
 		}
 
 		abort() {
 			const signal = this.signal;
-			protectedData.set(signal, { aborted: true });
-			signal.dispatchEvent(new Event('abort'));
+
+			if (! signal.aborted) {
+				signal[symbols.aborted] = true
+				signal.dispatchEvent(new Event('abort'));
+			}
 		}
+	};
+}
+
+if (! (AbortSignal.abort instanceof Function)) {
+	AbortSignal.abort = function abort() {
+		const controller = new AbortController();
+		controller.abort();
+		return controller.signal;
 	};
 }

--- a/abort-shims.js
+++ b/abort-shims.js
@@ -43,7 +43,7 @@ if (! ('AbortSignal' in globalThis)) {
 			const signal = this.signal;
 
 			if (! signal.aborted) {
-				signal[symbols.aborted] = true
+				signal[symbols.aborted] = true;
 				signal.dispatchEvent(new Event('abort'));
 			}
 		}

--- a/abort.js
+++ b/abort.js
@@ -1,8 +1,24 @@
 import './abort-shims.js';
-import { when } from './dom.js';
+import { when, beforeUnload, unloaded } from './dom.js';
 import { infinitPromise, getDeferred } from './promises.js';
 import { features, listen } from './events.js';
 export const supported =  'AbortController' in window && AbortController.prototype.hasOwnProperty('signal');
+
+export const unloadSignal = getUnloadSignal();
+
+export const beforeUnloadSignal = getBeforeUnloadSignal();
+
+export function getBeforeUnloadSignal() {
+	const controller = new AbortController();
+	beforeUnload().then(() => controller.abort());
+	return controller.signal;
+}
+
+export function getUnloadSignal() {
+	const controller = new AbortController();
+	unloaded().then(() => controller.abort());
+	return controller.signal;
+}
 
 export function isAborted(signal) {
 	if (signal instanceof AbortController) {

--- a/abort.js
+++ b/abort.js
@@ -1,16 +1,14 @@
 import './abort-shims.js';
-import { when, on } from './dom.js';
+import { when } from './dom.js';
 import { infinitPromise, getDeferred } from './promises.js';
-import { features } from './events.js';
+import { features, listen } from './events.js';
 export const supported =  'AbortController' in window && AbortController.prototype.hasOwnProperty('signal');
 
 export function isAborted(signal) {
 	if (signal instanceof AbortController) {
 		return signal.signal.aborted;
-	} else if (signal instanceof AbortSignal) {
-		return signal.aborted;
 	} else {
-		return false;
+		return signal instanceof AbortSignal && signal.aborted;
 	}
 }
 
@@ -33,6 +31,7 @@ export async function signalAborted(signal, { reason } = {}) {
 
 			signal.addEventListener('abort', callback);
 		}
+
 		return promise;
 	} else {
 		const { resolve, promise } = getDeferred();
@@ -59,8 +58,8 @@ export function abortButtonController(button) {
 	const controller = new AbortController();
 	button.disabled = false;
 
-	on(button, 'click', () => controller.abort(), { signal: controller.signal, once: true });
-	on(controller.signal, 'abort', () => button.disabled = true, { once: true });
+	listen(button, 'click', () => controller.abort(), { signal: controller.signal, once: true });
+	listen(controller.signal, 'abort', () => button.disabled = true, { once: true });
 
 	return controller;
 }

--- a/deprefixer.js
+++ b/deprefixer.js
@@ -1,17 +1,17 @@
 if (! ('crypto' in window) && 'msCrypto' in window) {
-	window.crypto = window.msCrypto;
+	globalThis.crypto = globalThis.msCrypto;
 }
 
 if (!('Notification' in window)) {
-	window.Notification = window.notifications || window.webkitNotifications || window.oNotifications || window.msNotifications || false;
+	globalThis.Notification = globalThis.notifications || globalThis.webkitNotifications || globalThis.oNotifications || globalThis.msNotifications || false;
 }
 
 if (!('doNotTrack' in navigator)) {
-	navigator.doNotTrack = window.doNotTrack || navigator.msDoNotTrack || 'unspecified';
+	navigator.doNotTrack = globalThis.doNotTrack || navigator.msDoNotTrack || 'unspecified';
 }
 
 if (!('indexedDB' in window)) {
-	window.indexedDB = window.indexedDB || window.mozIndexedDB || window.webkitIndexedDB || window.msIndexedDB || false;
+	globalThis.indexedDB = globalThis.indexedDB || globalThis.mozIndexedDB || globalThis.webkitIndexedDB || globalThis.msIndexedDB || false;
 }
 
 if (!('hidden' in document)) {
@@ -27,7 +27,7 @@ if (!('fullscreenElement' in document)) {
 }
 
 if (!('requestAnimationFrame' in window)) {
-	window.requestAnimationFrame = window.mozRequestAnimationFrame || window.webkitRequestAnimationFrame || window.msRequestAnimationFrame || false;
+	globalThis.requestAnimationFrame = globalThis.mozRequestAnimationFrame || globalThis.webkitRequestAnimationFrame || globalThis.msRequestAnimationFrame || false;
 }
 
 if (!('exitFullscreen' in Document.prototype)) {

--- a/dom.js
+++ b/dom.js
@@ -1,5 +1,5 @@
 import { signalAborted } from './abort.js';
-import { addListener } from './events.js';
+import { addListener, listen } from './events.js';
 import { getDeferred, isAsync } from './promises.js';
 
 export function query(what, base = document) {
@@ -449,15 +449,39 @@ export async function when(what, events, { capture, passive, signal, base } = {}
 }
 
 export async function ready({ signal } = {}) {
+	const { promise, resolve } = getDeferred();
+
 	if (document.readyState === 'loading') {
-		await when([document], ['DOMContentLoaded'], { signal });
+		listen(document, 'DOMContentLoaded', resolve, { signal, once: true, capture: true });
+	} else {
+		resolve();
 	}
+
+	return promise;
 }
 
 export async function loaded({ signal } = {}) {
+	const { promise, resolve } = getDeferred();
+
 	if (document.readyState !== 'complete') {
-		await when([window], ['load'], { signal });
+		listen(globalThis, 'load', resolve, { signal, once: true, capture: true });
+	} else {
+		resolve();
 	}
+
+	return promise;
+}
+
+export async function unloaded({ signal } = {}) {
+	const { promise, resolve } = getDeferred();
+	listen(globalThis, 'unload', resolve, { signal, once: true, capture: true });
+	return promise;
+}
+
+export async function beforeUnload({ signal } = {}) {
+	const { promise, resolve } = getDeferred();
+	listen(globalThis, 'beforeunload', resolve, { signal, once: true, capture: true });
+	return promise;
 }
 
 /**

--- a/events.js
+++ b/events.js
@@ -1,5 +1,6 @@
 import { query, when } from './dom.js';
 import { signalAborted } from './abort.js';
+import { getDeferred } from './promises.js';
 
 function getEventFeatures() {
 	const el = document.createElement('div');

--- a/promises.js
+++ b/promises.js
@@ -1,4 +1,4 @@
-import { when, ready, loaded } from './dom.js';
+import { when, ready, loaded, beforeUnload, unloaded } from './dom.js';
 import { signalAborted } from './abort.js';
 import { getManifest } from './http.js';
 import { listen } from './events.js';
@@ -10,13 +10,17 @@ export const readyPromise = ready();
 
 export const loadedPromise = loaded();
 
+export const unloadPromise = unloaded();
+
+export const beforeUnloadPromise = beforeUnload();
+
 export const manifestPromise = new Promise((resolve, reject) => {
 	readyPromise.then(() => getManifest()).then(resolve).catch(reject);
 });
 
 export const beforeInstallPromptPromise = new Promise(resolve => {
 	if ('onbeforeinstallprompt' in globalThis) {
-		globalThis.addEventListener('beforeinstallprompt', resolve, { once: true });
+		globalThis.addEventListener('beforeinstallprompt', resolve, { once: true, capture: true });
 	}
 });
 

--- a/pwa.js
+++ b/pwa.js
@@ -1,8 +1,8 @@
 import { getCustomElement } from './custom-elements.js';
 import { preload, loadScript } from './loader.js';
-import { resolveOn } from './promises.js';
+import { resolveOn, beforeInstallPromptPromise } from './promises.js';
 
-export const beforeInstallPrompt = resolveOn(window, 'beforeinstallprompt');
+export const beforeInstallPrompt = beforeInstallPromptPromise;
 
 export async function install() {
 	if (customElements.get('install-prompt') instanceof HTMLElement) {

--- a/pwa.js
+++ b/pwa.js
@@ -1,6 +1,6 @@
 import { getCustomElement } from './custom-elements.js';
 import { preload, loadScript } from './loader.js';
-import { resolveOn, beforeInstallPromptPromise } from './promises.js';
+import { beforeInstallPromptPromise } from './promises.js';
 
 export const beforeInstallPrompt = beforeInstallPromptPromise;
 


### PR DESCRIPTION
A wide variety of enhancements to async stuff.

- New `listen()` & `once()` functions in `events.js`
- Implement `AbortSignal.abort()`
- New exported promises for events (`load`, `beforeinstallprompt`, etc)
- More updating from `window` -> `globalThis`