### PR TITLE
Add event handlers for keyboard events

### DIFF
--- a/events.js
+++ b/events.js
@@ -68,6 +68,33 @@ export function listen(target, event, callback, { capture, once, passive, signal
 	}
 }
 
+export function onKeypress(key, callback, {
+	target = globalThis,
+	type = 'keypress',
+	capture,
+	once,
+	passive,
+	signal,
+	altKey,
+	ctrlKey,
+	metaKey,
+	shiftKey,
+} = {}) {
+	listen(target, type, function handler(event) {
+		if (
+			event.isTrusted && event.key.toLowerCase() === key.toLowerCase()
+			&& Object.entries({ ctrlKey, altKey, shiftKey, metaKey }).every(([name, value]) => {
+				return typeof value !== 'boolean' || event[name] === value;
+		})) {
+			if (once) {
+				target.removeEventListener(type, handler, { passive, capture, signal });
+			}
+
+			callback.call(this, event);
+		}
+	}, { passive, capture, signal });
+}
+
 export async function once(target, event, { capture, passive, signal } = {}) {
 	const { resolve, promise } = getDeferred({ signal, reason: new DOMException('Operation aborted') });
 	listen(target, event, resolve, { capture, once: true, passive, signal });

--- a/events.js
+++ b/events.js
@@ -85,7 +85,7 @@ export function onKeypress(key, callback, {
 			event.isTrusted && event.key.toLowerCase() === key.toLowerCase()
 			&& Object.entries({ ctrlKey, altKey, shiftKey, metaKey }).every(([name, value]) => {
 				return typeof value !== 'boolean' || event[name] === value;
-		})) {
+			})) {
 			if (once) {
 				target.removeEventListener(type, handler, { passive, capture, signal });
 			}

--- a/promises.js
+++ b/promises.js
@@ -1,7 +1,7 @@
 import { when, ready, loaded, beforeUnload, unloaded } from './dom.js';
 import { signalAborted } from './abort.js';
 import { getManifest } from './http.js';
-import { listen } from './events.js';
+import { listen, onKeypress } from './events.js';
 import { checkSupport as locksSupported } from './LockManager.js';
 
 export const infinitPromise = new Promise(() => {});
@@ -84,6 +84,22 @@ export async function callAsAsync(callback, args = [], {
 		});
 	}
 
+	return await promise;
+}
+
+export async function whenKeypress(key, {
+	target = globalThis,
+	type = 'keypress',
+	capture,
+	passive,
+	signal,
+	altKey,
+	ctrlKey,
+	metaKey,
+	shiftKey,
+} = {}) {
+	const { resolve, promise } = getDeferred({ signal });
+	onKeypress(key, resolve, { target, type, capture, once: true, passive, signal, altKey, ctrlKey, metaKey, shiftKey });
 	return await promise;
 }
 


### PR DESCRIPTION
Handles specific keys (e.g. `'a'`, instead of any key)

Also adds function for a promise which resolves when a specified key is pressed
