### PR TITLE
Various enhancements to Sanitizer & purify

### DIFF
--- a/SanitizerBase.js
+++ b/SanitizerBase.js
@@ -3,6 +3,8 @@ import { SanitizerConfig as defaultConfig } from './SanitizerConfigBase.js';
 import { nativeSupport, getSantizerUtils } from './sanitizerUtils.js';
 import { parseAsFragment, documentToFragment } from './dom.js';
 import { createPolicy } from './trust.js';
+import { urls } from './attributes.js';
+export const allowProtocols = ['https:'];
 
 /**
  * Need to create a policy for the Sanitizer API since
@@ -94,7 +96,10 @@ export class Sanitizer {
 							const name = node.name.toLowerCase();
 							const tag = ownerElement.tagName.toLowerCase();
 
-							if (name === 'href' && value.toLowerCase().startsWith('javascript:')) {
+							if (
+								urls.includes(name)
+								&& !allowProtocols.includes(new URL(value.trimStart().toLowerCase(), location.origin).protocol)
+							) {
 								ownerElement.removeAttributeNode(node);
 							} else if (typeof dropAttributes !== 'undefined') {
 								if (name in dropAttributes && ['*', tag].some(sel => dropAttributes[name].includes(sel))) {
@@ -105,7 +110,7 @@ export class Sanitizer {
 									}
 								}
 							} else if (typeof allowAttributes !== 'undefined') {
-								if (! (name in allowAttributes && ['*', tag].some(sel => allowAttributes[name].includes(sel)))) {
+								if (! name.startsWith('data-') && ! (name in allowAttributes && ['*', tag].some(sel => allowAttributes[name].includes(sel)))) {
 									ownerElement.removeAttributeNode(node);
 
 									if (name.startsWith('on')) {

--- a/SanitizerConfig.js
+++ b/SanitizerConfig.js
@@ -1,4 +1,5 @@
 import { allowComments, blockElements, dropElements } from './SanitizerConfigBase.js';
+import { events } from './attributes.js';
 export const allowAttributes = {
 	'abbr': ['*'],
 	// 'accept': ['*'],
@@ -181,13 +182,13 @@ export const allowAttributes = {
 	'span': ['*'],
 	'spellcheck': ['*'],
 	'src': ['img', 'script', 'source', 'audio', 'video'],
-	'srcdoc': ['iframe'],
+	// 'srcdoc': ['iframe'],
 	'srclang': ['*'],
 	'srcset': ['img'],
 	// 'standby': ['*'],
 	// 'start': ['*'],
 	'step': ['input'],
-	'style': ['*'],
+	// 'style': ['*'],
 	// 'summary': ['*'],
 	'tabindex': ['*'],
 	'target': ['a', 'form'],
@@ -331,7 +332,10 @@ export const allowElements = [
 	'wbr'
 ];
 
-export const dropAttributes = undefined;
+export const dropAttributes = {
+	'style': ['*'],
+	...Object.fromEntries(events.map(ev => [ev, ['*']])),
+};
 
 export const SanitizerConfig = {
 	allowAttributes, allowComments, allowElements, allowCustomElements,

--- a/purify.js
+++ b/purify.js
@@ -1,5 +1,5 @@
 import { createPolicy } from './trust.js';
-import { events } from './attributes.js';
+import { events, urls } from './attributes.js';
 
 /**
  * TrustedTypePolicy for internal use
@@ -7,7 +7,8 @@ import { events } from './attributes.js';
  */
 const nullPolicy = createPolicy('purify-raw#html', { createHTML: input => input });
 const tags = ['script', 'object', 'embed', 'param', 'head', 'body', 'frame', 'noscript'];
-const attributes = [...events, 'ping'];
+const attributes = [...events, 'ping', 'style'];
+const protocols = ['https:'];
 
 /**
  * [sanitize description]
@@ -44,9 +45,12 @@ function sanitize(node) {
 			const { value, ownerElement } = node;
 			const name = node.name.toLowerCase();
 
-			if (name === 'href' && value.toLowerCase().startsWith('javascript:')) {
+			if (
+				urls.includes(name)
+				&& !protocols.includes(new URL(value.trimStart().toLowerCase(), location.origin)).protocol
+			) {
 				ownerElement.removeAttributeNode(node);
-			} else if (attributes.includes(name.toLowerCase())) {
+			} else if (attributes.includes(name)) {
 				ownerElement.removeAttributeNode(node);
 			}
 


### PR DESCRIPTION
- Only trust URL attributes with `https:` protocol
- `trim()` attribute values when checking URLs
- Disallow `style` attributes
- Allow `data-*` attributes