### PR TITLE
Create text encoder/decoder polyfills & hashing/crypto enhancements

### DIFF
--- a/HMAC.js
+++ b/HMAC.js
@@ -1,0 +1,106 @@
+import { SHA_512, SHA_384, SHA_256, SHA, bufferToHex, hexToBuffer } from './hash.js';
+export const ALGOS = [SHA_512, SHA_384, SHA_256, SHA];
+export const DEFAULT_ALGO = SHA_512;
+
+const symbols = {
+	key: Symbol('key'),
+	encoder: Symbol('encoder'),
+	algorithm: Symbol('algorithm'),
+};
+
+export class HMAC {
+	constructor(password, { algorithm = DEFAULT_ALGO } = {}) {
+		const encoder = new TextEncoder();
+		Object.defineProperties(this, {
+			[symbols.algorithm]: {
+				configurable: false,
+				enumerable: false,
+				writable: false,
+				value: algorithm,
+			},
+			[symbols.encoder]: {
+				configurable: false,
+				enumerable: false,
+				writable: false,
+				value: encoder,
+			},
+			[symbols.key]: {
+				configurable: false,
+				enumerable: false,
+				writable: false,
+				value: HMAC.generateKey(password, { algorithm, encoder }),
+			},
+		});
+	}
+
+	get algorithm() {
+		return this[symbols.algorithm];
+	}
+
+	get encoding() {
+		return this[symbols.encoder].encoding;
+	}
+
+	async sign(data) {
+		if (! (data instanceof ArrayBuffer)) {
+			throw new TypeError('`sign()` accepts an ArrayBuffer');
+		} else {
+				const key = await this[symbols.key];
+				const buffer = await crypto.subtle.sign({ name: key.algorithm.name }, key, data);
+				return bufferToHex(buffer);
+		}
+	}
+
+	async signText(str) {
+		if (typeof str !== 'string') {
+			throw new TypeError('Expected a string');
+		} else {
+			return this.sign(this[symbols.encoder].encode(str).buffer);
+		}
+	}
+
+	async signFile(file) {
+		if (! (file instanceof File)) {
+			throw new TypeError('Expected a file');
+		} else {
+			return this.sign(await file.arrayBuffer());
+		}
+	}
+
+	async verify(data, signature) {
+		if (typeof signature !== 'string') {
+			throw new DOMException('Missing signture to verify');
+		} else if (! (data instanceof ArrayBuffer)) {
+			throw new TypeError('`verify()` requires an ArrayBuffer and hex signature');
+		} else {
+			const key = await this[symbols.key];
+			return await crypto.subtle.verify({ name: key.algorithm.name }, key, hexToBuffer(signature), data);
+		}
+	}
+
+	async verifyText(str, signature) {
+		if (typeof str !== 'string') {
+			throw new TypeError('Expected a string');
+		} else {
+			return this.verify(this[symbols.encoder].encode(str).buffer, signature);
+		}
+	}
+
+	async verifyFile(file, signature) {
+		if (! (file instanceof File)) {
+			throw new TypeError('Expected a file');
+		} else {
+			return this.verify(await file.arrayBuffer(), signature);
+		}
+	}
+
+	static async generateKey(password, { algorithm: hash = DEFAULT_ALGO, encoder = new TextEncoder() } = {}) {
+		return await crypto.subtle.importKey(
+			'raw',
+			encoder.encode(password),
+			{ name: 'HMAC', hash },
+			true,
+			['sign', 'verify']
+		);
+	}
+}

--- a/HMAC.js
+++ b/HMAC.js
@@ -1,5 +1,5 @@
-import { SHA_512, SHA_384, SHA_256, SHA, bufferToHex, hexToBuffer } from './hash.js';
-export const ALGOS = [SHA_512, SHA_384, SHA_256, SHA];
+import { SHA_512, SHA_384, SHA_256, SHA_1, bufferToHex, hexToBuffer } from './hash.js';
+export const ALGOS = [SHA_512, SHA_384, SHA_256, SHA_1];
 export const DEFAULT_ALGO = SHA_512;
 
 const symbols = {

--- a/HMAC.js
+++ b/HMAC.js
@@ -45,9 +45,9 @@ export class HMAC {
 		if (! (data instanceof ArrayBuffer)) {
 			throw new TypeError('`sign()` accepts an ArrayBuffer');
 		} else {
-				const key = await this[symbols.key];
-				const buffer = await crypto.subtle.sign({ name: key.algorithm.name }, key, data);
-				return bufferToHex(buffer);
+			const key = await this[symbols.key];
+			const buffer = await crypto.subtle.sign({ name: key.algorithm.name }, key, data);
+			return bufferToHex(buffer);
 		}
 	}
 

--- a/TextDecoder.js
+++ b/TextDecoder.js
@@ -77,4 +77,4 @@ export class TextDecoder {
 				throw new TypeError(`Unsupported encoding '${this.encoding}'`);
 		}
 	}
-};
+}

--- a/TextDecoder.js
+++ b/TextDecoder.js
@@ -1,0 +1,81 @@
+/**
+ *
+ * Array of supported encodings
+ * @Todo: At least add utf-16
+ * @type {Array}
+ */
+const supportedEncodings = ['utf-8', 'utf8'];
+
+export const BOM = new Uint8Array([0xEF, 0xBB, 0xBF]);
+
+export class TextDecoder {
+	constructor(encoding = 'utf-8', { fatal = false, ignoreBOM = false } = {}) {
+		if (typeof encoding !== 'string') {
+			encoding = encoding.toString().toLowerCase();
+		} else {
+			encoding = encoding.toLowerCase();
+		}
+
+		if (! supportedEncodings.includes(encoding)) {
+			throw new RangeError(`TextDecoder constructor: The given encoding '${encoding}' is not supported.`);
+		}
+
+		Object.defineProperties(this, {
+			encoding: {
+				configurable: false,
+				enumerable: true,
+				writable: false,
+				value: encoding,
+			},
+			fatal: {
+				configurable: false,
+				enumerable: true,
+				writable: false,
+				value: fatal,
+			},
+			ignoreBOM: {
+				configurable: false,
+				enumerable: true,
+				writable: false,
+				value: ignoreBOM,
+			},
+		});
+	}
+
+	decode(data) {
+		const { encoding, fatal } = this;
+		switch(encoding) {
+			case 'utf-8':
+			case 'utf8': {
+				let prev = NaN;
+				// debugger;
+				return data.reduce((str, i) => {
+					console.log({ i, prev });
+					if (i < 128 && Number.isNaN(prev)) {
+						return str + String.fromCharCode(i);
+					} else if (Number.isNaN(prev)) {
+						prev = i;
+						return str;
+					} else if (i > 127 && ! Number.isNaN(prev)) {
+						/**
+						* const prev = 194 + Math.floor((i - 128) / 64);
+						* return [prev, (code % 64) + 128];
+						*/
+						const mod = Math.min(0, prev - 194) * 64;
+						const char = String.fromCharCode(mod + i + 128);
+						const encoded = new TextEncoder().encode(char);
+						console.log({ mod, i, char, encoded: `[${encoded.join(', ')}]` });
+						prev = NaN;
+						return str + char;
+					} else if (fatal) {
+						throw new DOMException(`Invalid char index: ${i}`)
+					}
+				}, '');
+
+			}
+
+			default:
+				throw new TypeError(`Unsupported encoding '${this.encoding}'`);
+		}
+	}
+};

--- a/TextEncoder.js
+++ b/TextEncoder.js
@@ -1,0 +1,38 @@
+export class TextEncoder {
+	get encoding() {
+		return 'utf-8';
+	}
+
+	encode(str) {
+		// Identical to char up to 127, then [194, (n)] for n=(128-191),
+		// then [194, (128-191)] for n=(192-255)
+		// and it looks like this holds in intervals of 64
+		return new Uint8Array(str.split('').flatMap(char => {
+			const code = char.charCodeAt(0);
+
+			if (code < 128) {
+				return [code];
+			} else {
+				const pt = 194 + Math.floor((code - 128) / 64);
+				return [pt, (code % 64) + 128];
+			}
+		}));
+	}
+
+	encodeInto(str, ui8arr) {
+		if (! (ui8arr instanceof Uint8Array)) {
+			throw new TypeError('TextEncoder.encodeInto: Argument 2 does not implement interface Uint8Array.');
+		} else {
+			const encoded = this.encode(str);
+			const len = Math.min(ui8arr.length, encoded.length);
+
+			if (encoded.length > ui8arr.length) {
+				ui8arr.set(encoded.slice(0, len));
+			} else {
+				ui8arr.set(encoded);
+			}
+
+			return { read: len, written: len };
+		}
+	}
+}

--- a/hash.js
+++ b/hash.js
@@ -1,271 +1,50 @@
+export const SHA = 'SHA-1';
+export const SHA_256 = 'SHA-256';
+export const SHA_384 = 'SHA-384';
+export const SHA_512 = 'SHA-512';
+export { default  as md5 } from './md5.js';
+
+export function bufferToHex(buffer) {
+	if (! (buffer instanceof ArrayBuffer)) {
+		throw new TypeError('`bufferToHex()` requires an ArrayBuffer');
+	} else {
+		return [...new Uint8Array(buffer)].map(value =>  value.toString(16).padStart(2, '0')).join('');
+	}
+}
+
+export function hexToBuffer(hex) {
+	if (typeof hex !== 'string') {
+		throw new TypeError('`hexToBuffer()` only accepts strings');
+	} else if (hex.length === 0) {
+		throw new TypeError('Empty string');
+	} else if (hex.length % 2 !== 0) {
+		throw new TypeError('Strings must be an even length');
+	} else {
+		return  new Uint8Array(hex.match(/[\da-f]{2}/gi).map(h => parseInt(h, 16))).buffer;
+	}
+}
+
 export function sha1(data) {
-	return hash(data, 'SHA-1');
+	return hash(data, SHA_1);
 }
 
 export function sha256(data) {
-	return hash(data, 'SHA-256');
+	return hash(data, SHA_256);
 }
 
 export function sha384(data) {
-	return hash(data, 'SHA-384');
+	return hash(data, SHA_384);
 }
 
 export function sha512(data) {
-	return hash(data, 'sha-512');
+	return hash(data, SHA_512);
 }
 
-export async function hash(data, algo = 'SHA-1') {
+export async function hash(data, algo = SHA_256) {
 	if (typeof data === 'string') {
 		data = new TextEncoder().encode(data);
 	}
 	const buffer = await crypto.subtle.digest(algo.toUpperCase(), data);
 
-	return [...new Uint8Array(buffer)].map(value => {
-		const hexCode = value.toString(16).toUpperCase();
-		const paddedHexCode = hexCode.padStart(2, '0');
-		return paddedHexCode;
-	}).join('').toLowerCase();
-}
-
-function safeAdd (x, y) {
-	var lsw = (x & 0xFFFF) + (y & 0xFFFF);
-	var msw = (x >> 16) + (y >> 16) + (lsw >> 16);
-	return (msw << 16) | (lsw & 0xFFFF);
-}
-
-/*
-* Bitwise rotate a 32-bit number to the left.
-*/
-function bitRotateLeft (num, cnt) {
-	return (num << cnt) | (num >>> (32 - cnt));
-}
-
-/*
-* These functions implement the four basic operations the algorithm uses.
-*/
-function md5cmn (q, a, b, x, s, t) {
-	return safeAdd(bitRotateLeft(safeAdd(safeAdd(a, q), safeAdd(x, t)), s), b);
-}
-function md5ff (a, b, c, d, x, s, t) {
-	return md5cmn((b & c) | ((~b) & d), a, b, x, s, t);
-}
-function md5gg (a, b, c, d, x, s, t) {
-	return md5cmn((b & d) | (c & (~d)), a, b, x, s, t);
-}
-function md5hh (a, b, c, d, x, s, t) {
-	return md5cmn(b ^ c ^ d, a, b, x, s, t);
-}
-function md5ii (a, b, c, d, x, s, t) {
-	return md5cmn(c ^ (b | (~d)), a, b, x, s, t);
-}
-
-/*
-* Calculate the MD5 of an array of little-endian words, and a bit length.
-*/
-function binlMD5 (x, len) {
-	/* append padding */
-	x[len >> 5] |= 0x80 << (len % 32);
-	x[(((len + 64) >>> 9) << 4) + 14] = len;
-
-	var i;
-	var olda;
-	var oldb;
-	var oldc;
-	var oldd;
-	var a = 1732584193;
-	var b = -271733879;
-	var c = -1732584194;
-	var d = 271733878;
-
-	for (i = 0; i < x.length; i += 16) {
-		olda = a;
-		oldb = b;
-		oldc = c;
-		oldd = d;
-
-		a = md5ff(a, b, c, d, x[i], 7, -680876936);
-		d = md5ff(d, a, b, c, x[i + 1], 12, -389564586);
-		c = md5ff(c, d, a, b, x[i + 2], 17, 606105819);
-		b = md5ff(b, c, d, a, x[i + 3], 22, -1044525330);
-		a = md5ff(a, b, c, d, x[i + 4], 7, -176418897);
-		d = md5ff(d, a, b, c, x[i + 5], 12, 1200080426);
-		c = md5ff(c, d, a, b, x[i + 6], 17, -1473231341);
-		b = md5ff(b, c, d, a, x[i + 7], 22, -45705983);
-		a = md5ff(a, b, c, d, x[i + 8], 7, 1770035416);
-		d = md5ff(d, a, b, c, x[i + 9], 12, -1958414417);
-		c = md5ff(c, d, a, b, x[i + 10], 17, -42063);
-		b = md5ff(b, c, d, a, x[i + 11], 22, -1990404162);
-		a = md5ff(a, b, c, d, x[i + 12], 7, 1804603682);
-		d = md5ff(d, a, b, c, x[i + 13], 12, -40341101);
-		c = md5ff(c, d, a, b, x[i + 14], 17, -1502002290);
-		b = md5ff(b, c, d, a, x[i + 15], 22, 1236535329);
-
-		a = md5gg(a, b, c, d, x[i + 1], 5, -165796510);
-		d = md5gg(d, a, b, c, x[i + 6], 9, -1069501632);
-		c = md5gg(c, d, a, b, x[i + 11], 14, 643717713);
-		b = md5gg(b, c, d, a, x[i], 20, -373897302);
-		a = md5gg(a, b, c, d, x[i + 5], 5, -701558691);
-		d = md5gg(d, a, b, c, x[i + 10], 9, 38016083);
-		c = md5gg(c, d, a, b, x[i + 15], 14, -660478335);
-		b = md5gg(b, c, d, a, x[i + 4], 20, -405537848);
-		a = md5gg(a, b, c, d, x[i + 9], 5, 568446438);
-		d = md5gg(d, a, b, c, x[i + 14], 9, -1019803690);
-		c = md5gg(c, d, a, b, x[i + 3], 14, -187363961);
-		b = md5gg(b, c, d, a, x[i + 8], 20, 1163531501);
-		a = md5gg(a, b, c, d, x[i + 13], 5, -1444681467);
-		d = md5gg(d, a, b, c, x[i + 2], 9, -51403784);
-		c = md5gg(c, d, a, b, x[i + 7], 14, 1735328473);
-		b = md5gg(b, c, d, a, x[i + 12], 20, -1926607734);
-
-		a = md5hh(a, b, c, d, x[i + 5], 4, -378558);
-		d = md5hh(d, a, b, c, x[i + 8], 11, -2022574463);
-		c = md5hh(c, d, a, b, x[i + 11], 16, 1839030562);
-		b = md5hh(b, c, d, a, x[i + 14], 23, -35309556);
-		a = md5hh(a, b, c, d, x[i + 1], 4, -1530992060);
-		d = md5hh(d, a, b, c, x[i + 4], 11, 1272893353);
-		c = md5hh(c, d, a, b, x[i + 7], 16, -155497632);
-		b = md5hh(b, c, d, a, x[i + 10], 23, -1094730640);
-		a = md5hh(a, b, c, d, x[i + 13], 4, 681279174);
-		d = md5hh(d, a, b, c, x[i], 11, -358537222);
-		c = md5hh(c, d, a, b, x[i + 3], 16, -722521979);
-		b = md5hh(b, c, d, a, x[i + 6], 23, 76029189);
-		a = md5hh(a, b, c, d, x[i + 9], 4, -640364487);
-		d = md5hh(d, a, b, c, x[i + 12], 11, -421815835);
-		c = md5hh(c, d, a, b, x[i + 15], 16, 530742520);
-		b = md5hh(b, c, d, a, x[i + 2], 23, -995338651);
-
-		a = md5ii(a, b, c, d, x[i], 6, -198630844);
-		d = md5ii(d, a, b, c, x[i + 7], 10, 1126891415);
-		c = md5ii(c, d, a, b, x[i + 14], 15, -1416354905);
-		b = md5ii(b, c, d, a, x[i + 5], 21, -57434055);
-		a = md5ii(a, b, c, d, x[i + 12], 6, 1700485571);
-		d = md5ii(d, a, b, c, x[i + 3], 10, -1894986606);
-		c = md5ii(c, d, a, b, x[i + 10], 15, -1051523);
-		b = md5ii(b, c, d, a, x[i + 1], 21, -2054922799);
-		a = md5ii(a, b, c, d, x[i + 8], 6, 1873313359);
-		d = md5ii(d, a, b, c, x[i + 15], 10, -30611744);
-		c = md5ii(c, d, a, b, x[i + 6], 15, -1560198380);
-		b = md5ii(b, c, d, a, x[i + 13], 21, 1309151649);
-		a = md5ii(a, b, c, d, x[i + 4], 6, -145523070);
-		d = md5ii(d, a, b, c, x[i + 11], 10, -1120210379);
-		c = md5ii(c, d, a, b, x[i + 2], 15, 718787259);
-		b = md5ii(b, c, d, a, x[i + 9], 21, -343485551);
-
-		a = safeAdd(a, olda);
-		b = safeAdd(b, oldb);
-		c = safeAdd(c, oldc);
-		d = safeAdd(d, oldd);
-	}
-	return [a, b, c, d];
-}
-
-/*
-* Convert an array of little-endian words to a string
-*/
-function binl2rstr (input) {
-	var i;
-	var output = '';
-	var length32 = input.length * 32;
-	for (i = 0; i < length32; i += 8) {
-		output += String.fromCharCode((input[i >> 5] >>> (i % 32)) & 0xFF);
-	}
-	return output;
-}
-
-/*
-* Convert a raw string to an array of little-endian words
-* Characters >255 have their high-byte silently ignored.
-*/
-function rstr2binl (input) {
-	var i;
-	var output = [];
-	output[(input.length >> 2) - 1] = undefined;
-	for (i = 0; i < output.length; i += 1) {
-		output[i] = 0;
-	}
-	var length8 = input.length * 8;
-	for (i = 0; i < length8; i += 8) {
-		output[i >> 5] |= (input.charCodeAt(i / 8) & 0xFF) << (i % 32);
-	}
-	return output;
-}
-
-/*
-* Calculate the MD5 of a raw string
-*/
-function rstrMD5 (s) {
-	return binl2rstr(binlMD5(rstr2binl(s), s.length * 8));
-}
-
-/*
-* Calculate the HMAC-MD5, of a key and some data (raw strings)
-*/
-function rstrHMACMD5 (key, data) {
-	var i;
-	var bkey = rstr2binl(key);
-	var ipad = [];
-	var opad = [];
-	var hash;
-	ipad[15] = opad[15] = undefined;
-	if (bkey.length > 16) {
-		bkey = binlMD5(bkey, key.length * 8);
-	}
-	for (i = 0; i < 16; i += 1) {
-		ipad[i] = bkey[i] ^ 0x36363636;
-		opad[i] = bkey[i] ^ 0x5C5C5C5C;
-	}
-	hash = binlMD5(ipad.concat(rstr2binl(data)), 512 + data.length * 8);
-	return binl2rstr(binlMD5(opad.concat(hash), 512 + 128));
-}
-
-/*
-* Convert a raw string to a hex string
-*/
-function rstr2hex (input) {
-	var hexTab = '0123456789abcdef';
-	var output = '';
-	var x;
-	var i;
-	for (i = 0; i < input.length; i += 1) {
-		x = input.charCodeAt(i);
-		output += hexTab.charAt((x >>> 4) & 0x0F) +
-				hexTab.charAt(x & 0x0F);
-	}
-	return output;
-}
-
-/*
-* Encode a string as utf-8
-*/
-function str2rstrUTF8 (input) {
-	return unescape(encodeURIComponent(input));
-}
-
-/*
-* Take string arguments and return either raw or hex encoded strings
-*/
-function rawMD5 (s) {
-	return rstrMD5(str2rstrUTF8(s));
-}
-function hexMD5 (s) {
-	return rstr2hex(rawMD5(s));
-}
-function rawHMACMD5 (k, d) {
-	return rstrHMACMD5(str2rstrUTF8(k), str2rstrUTF8(d));
-}
-function hexHMACMD5 (k, d) {
-	return rstr2hex(rawHMACMD5(k, d));
-}
-
-export async function md5 (string, key, raw) {
-	if (!key) {
-		if (!raw) {
-			return hexMD5(string);
-		}
-		return rawMD5(string);
-	}
-	if (!raw) {
-		return hexHMACMD5(key, string);
-	}
-	return rawHMACMD5(key, string);
+	return bufferToHex(buffer);
 }

--- a/hash.js
+++ b/hash.js
@@ -1,8 +1,12 @@
-export const SHA = 'SHA-1';
+export const SHA_1 = 'SHA-1';
 export const SHA_256 = 'SHA-256';
 export const SHA_384 = 'SHA-384';
 export const SHA_512 = 'SHA-512';
-export { default  as md5 } from './md5.js';
+import { default  as md5Shim } from './md5.js';
+
+export async function md5(str) {
+	return md5Shim(str);
+}
 
 export function bufferToHex(buffer) {
 	if (! (buffer instanceof ArrayBuffer)) {
@@ -41,10 +45,13 @@ export function sha512(data) {
 }
 
 export async function hash(data, algo = SHA_256) {
-	if (typeof data === 'string') {
-		data = new TextEncoder().encode(data);
-	}
-	const buffer = await crypto.subtle.digest(algo.toUpperCase(), data);
+	if (data instanceof ArrayBuffer) {
+		const buffer = await crypto.subtle.digest(algo.toUpperCase(), data);
 
-	return bufferToHex(buffer);
+		return bufferToHex(buffer);
+	} else if (data instanceof File) {
+		return hash(await data.arrayBuffer(), algo);
+	} else if (typeof data === 'string') {
+		return hash(new TextEncoder().encode(data), algo);
+	}
 }

--- a/integrity.js
+++ b/integrity.js
@@ -1,6 +1,4 @@
-const SHA_256 = 'SHA-256';
-const SHA_384 = 'SHA-384';
-const SHA_512 = 'SHA-512';
+import { SHA_256, SHA_384, SHA_512 } from './hash.js';
 
 export const DEFAULT_ALGO = SHA_384;
 export const ALGOS = [SHA_256, SHA_384, SHA_512];
@@ -9,7 +7,7 @@ export async function fromArrayBuffer(data, { algo = DEFAULT_ALGO } = {}) {
 	const buffer = await crypto.subtle.digest(algo.toUpperCase(), data);
 	const codeUnits = new Uint16Array(buffer);
 	const charCodes = new Uint8Array(codeUnits.buffer);
-	const hash = btoa([...charCodes].map(code => String.fromCharCode(code)).join(''));
+	const hash = btoa(String.fromCharCode(...charCodes));
 	return `${algo.replace('-', '').toLowerCase()}-${hash}`;
 }
 

--- a/shims/textEncoder.js
+++ b/shims/textEncoder.js
@@ -1,0 +1,85 @@
+if (! ('TextEncoder' in globalThis)) {
+	globalThis.TextEncoder = class TextEncoder {
+		get encoding() {
+			return 'utf-8';
+		}
+
+		encode(str) {
+			return new Uint8Array(str.split('').map(char => char.charCodeAt(0)));
+		}
+	};
+}
+
+if (! ('TextDecoder' in globalThis)) {
+	/**
+	 * Array of supported encodings
+	 * @Todo: At least add utf-16
+	 * @type {Array}
+	 */
+	const supportedEncodings = ['utf-8', 'utf8'];
+
+	globalThis.TextDecoder = class TextDecoder {
+		constructor(encoding = 'utf-8', { fatal = false, ignoreBOM = false } = {}) {
+			if (typeof encoding !== 'string') {
+				encoding = encoding.toString().toLowerCase();
+			} else {
+				encoding = encoding.toLowerCase();
+			}
+
+			if (! supportedEncodings.includes(encoding)) {
+				throw new RangeError(`TextDecoder constructor: The given encoding '${encoding}' is not supported.`);
+			}
+
+			Object.defineProperties(this, {
+				encoding: {
+					configurable: false,
+					enumerable: true,
+					writable: false,
+					value: encoding,
+				},
+				fatal: {
+					configurable: false,
+					enumerable: true,
+					writable: false,
+					value: fatal,
+				},
+				ignoreBOM: {
+					configurable: false,
+					enumerable: true,
+					writable: false,
+					value: ignoreBOM,
+				},
+			});
+		}
+
+		decode(data) {
+			switch(this.encoding) {
+				case 'utf-8':
+				case 'utf8':
+					return String.fromCharCode(...data);
+
+				default:
+					throw new TypeError(`Unsupported encoding '${this.encoding}'`);
+			}
+		}
+	};
+}
+
+if (! (TextEncoder.prototype.encodeInto instanceof Function)) {
+	TextEncoder.prototype.encodeInto = function(str, ui8arr) {
+		if (! (ui8arr instanceof Uint8Array)) {
+			throw new TypeError('TextEncoder.encodeInto: Argument 2 does not implement interface Uint8Array.');
+		} else {
+			const encoded = this.encode(str);
+			const len = Math.min(ui8arr.length, encoded.length);
+
+			if (encoded.length > ui8arr.length) {
+				ui8arr.set(encoded.slice(0, len));
+			} else {
+				ui8arr.set(encoded);
+			}
+
+			return { read: len, written: len };
+		}
+	}
+}

--- a/shims/textEncoder.js
+++ b/shims/textEncoder.js
@@ -1,72 +1,16 @@
-if (! ('TextEncoder' in globalThis)) {
-	globalThis.TextEncoder = class TextEncoder {
-		get encoding() {
-			return 'utf-8';
-		}
+import { TextEncoder } from '../TextEncoder.js';
+import { TextDecoder } from '../TextDecoder.js';
 
-		encode(str) {
-			return new Uint8Array(str.split('').map(char => char.charCodeAt(0)));
-		}
-	};
+if (! ('TextEncoder' in globalThis)) {
+	globalThis.TextEncoder = TextEncoder;
 }
 
 if (! ('TextDecoder' in globalThis)) {
-	/**
-	 * Array of supported encodings
-	 * @Todo: At least add utf-16
-	 * @type {Array}
-	 */
-	const supportedEncodings = ['utf-8', 'utf8'];
-
-	globalThis.TextDecoder = class TextDecoder {
-		constructor(encoding = 'utf-8', { fatal = false, ignoreBOM = false } = {}) {
-			if (typeof encoding !== 'string') {
-				encoding = encoding.toString().toLowerCase();
-			} else {
-				encoding = encoding.toLowerCase();
-			}
-
-			if (! supportedEncodings.includes(encoding)) {
-				throw new RangeError(`TextDecoder constructor: The given encoding '${encoding}' is not supported.`);
-			}
-
-			Object.defineProperties(this, {
-				encoding: {
-					configurable: false,
-					enumerable: true,
-					writable: false,
-					value: encoding,
-				},
-				fatal: {
-					configurable: false,
-					enumerable: true,
-					writable: false,
-					value: fatal,
-				},
-				ignoreBOM: {
-					configurable: false,
-					enumerable: true,
-					writable: false,
-					value: ignoreBOM,
-				},
-			});
-		}
-
-		decode(data) {
-			switch(this.encoding) {
-				case 'utf-8':
-				case 'utf8':
-					return String.fromCharCode(...data);
-
-				default:
-					throw new TypeError(`Unsupported encoding '${this.encoding}'`);
-			}
-		}
-	};
+	globalThis.TextDecoder = TextDecoder;
 }
 
-if (! (TextEncoder.prototype.encodeInto instanceof Function)) {
-	TextEncoder.prototype.encodeInto = function(str, ui8arr) {
+if (! (globalThis.TextEncoder.prototype.encodeInto instanceof Function)) {
+	globalThis.TextEncoder.prototype.encodeInto = function(str, ui8arr) {
 		if (! (ui8arr instanceof Uint8Array)) {
 			throw new TypeError('TextEncoder.encodeInto: Argument 2 does not implement interface Uint8Array.');
 		} else {

--- a/shims/textEncoder.js
+++ b/shims/textEncoder.js
@@ -25,5 +25,5 @@ if (! (globalThis.TextEncoder.prototype.encodeInto instanceof Function)) {
 
 			return { read: len, written: len };
 		}
-	}
+	};
 }

--- a/shims/textEncoder.js
+++ b/shims/textEncoder.js
@@ -11,6 +11,6 @@ if (! ('TextDecoder' in globalThis)) {
 
 if (! (globalThis.TextEncoder.prototype.encodeInto instanceof Function)) {
 	globalThis.TextEncoder.prototype.encodeInto = function(...args) {
-		return TextEncoder.prototype.encodeInto.apply(this, args)
+		return TextEncoder.prototype.encodeInto.apply(this, args);
 	};
 }

--- a/shims/textEncoder.js
+++ b/shims/textEncoder.js
@@ -10,20 +10,7 @@ if (! ('TextDecoder' in globalThis)) {
 }
 
 if (! (globalThis.TextEncoder.prototype.encodeInto instanceof Function)) {
-	globalThis.TextEncoder.prototype.encodeInto = function(str, ui8arr) {
-		if (! (ui8arr instanceof Uint8Array)) {
-			throw new TypeError('TextEncoder.encodeInto: Argument 2 does not implement interface Uint8Array.');
-		} else {
-			const encoded = this.encode(str);
-			const len = Math.min(ui8arr.length, encoded.length);
-
-			if (encoded.length > ui8arr.length) {
-				ui8arr.set(encoded.slice(0, len));
-			} else {
-				ui8arr.set(encoded);
-			}
-
-			return { read: len, written: len };
-		}
+	globalThis.TextEncoder.prototype.encodeInto = function(...args) {
+		return TextEncoder.prototype.encodeInto.apply(this, args)
 	};
 }


### PR DESCRIPTION
- Create `TextEncoder` polyfill
- Create `TextDecoder` polyfill
- Create `HMAC` class with methods to sign & verify buffers, text, & files
- Remove `md5` code from `hash.js` and just `export { default as md5 } from './md5.js';`
- Create & use various hashing consts (e.g. `SHA_512` instead of `'SHA-512'`).