### PR TITLE
Update `.emplace()` methods to match spec

### DIFF
--- a/shims/map.js
+++ b/shims/map.js
@@ -4,17 +4,22 @@
 
 if (! (Map.prototype.emplace instanceof Function)) {
 	Map.prototype.emplace = function emplace(key, { insert, update } = {}) {
-		const existing = this.get(key);
+		const has = this.has(key);
 
-		if (typeof existing === 'undefined' && insert instanceof Function) {
+		if (has && update instanceof Function) {
+			const existing = this.get(key);
+			const value = update.call(this, existing, key, this);
+
+			if (value !== existing) {
+				this.set(key, existing);
+			}
+
+			return value;
+		} else if (has) {
+			return this.get(key);
+		} else if (insert instanceof Function) {
 			const value = insert.call(this, key, this);
 			this.set(key, value);
-			return value;
-		} else if (typeof existing !== 'undefined' && update instanceof Function) {
-			const value = update.call(this, existing, key, this);
-			if (value !== existing) {
-				this.set(key, value);
-			}
 			return value;
 		} else {
 			throw new Error('Key is not found and no `insert()` given');

--- a/shims/weakMap.js
+++ b/shims/weakMap.js
@@ -1,16 +1,21 @@
 if (! (WeakMap.prototype.emplace instanceof Function)) {
 	WeakMap.prototype.emplace = function emplace(key, { insert, update } = {}) {
-		const existing = this.get(key);
+		const has = this.has(key);
 
-		if (typeof existing === 'undefined' && insert instanceof Function) {
+		if (has && update instanceof Function) {
+			const existing = this.get(key);
+			const value = update.call(this, existing, key, this);
+
+			if (value !== existing) {
+				this.set(key, existing);
+			}
+
+			return value;
+		} else if (has) {
+			return this.get(key);
+		} else if (insert instanceof Function) {
 			const value = insert.call(this, key, this);
 			this.set(key, value);
-			return value;
-		} else if (typeof existing !== 'undefined' && update instanceof Function) {
-			const value = update.call(this, existing, key, this);
-			if (value !== existing) {
-				this.set(key, value);
-			}
 			return value;
 		} else {
 			throw new Error('Key is not found and no `insert()` given');


### PR DESCRIPTION
- It is possible that `map.get(key)` could have a value of `undefined`, so do need to check `map.has(key)` instead.
- Handle case where `map.has(key)` but no update function given

I'm returning `map.get(key)` for cases where `map.has(key)` but no update callback is given. No instructions are given for this case, but the document gives reason why it should never return `undefined`... So it should return *something*, and the current value is the only thing that makes any sense.

# Description and issue

## List of significant changes made
-  
-  
