### PR TITLE
Remove `unloadSignal` & `beforeUnloadSignal`

### DIFF
--- a/abort.js
+++ b/abort.js
@@ -3,10 +3,6 @@ import { getDeferred } from './promises.js';
 import { listen } from './events.js';
 export const supported =  'AbortController' in window && AbortController.prototype.hasOwnProperty('signal');
 
-export const unloadSignal = getUnloadSignal();
-
-export const beforeUnloadSignal = getBeforeUnloadSignal();
-
 export function throwIfAborted(signal) {
 	if (signal instanceof AbortController) {
 		signal.signal.throwIfAborted();


### PR DESCRIPTION
These cause issues with back/forward cache as the listeners delay their events.

![image](https://user-images.githubusercontent.com/1627459/182438180-a19aeaa0-1a45-4f3b-a935-c91952875bc4.png)
