### PR TITLE
Create `getURLResolver()` function

### DIFF
--- a/utility.js
+++ b/utility.js
@@ -2,6 +2,12 @@ import { randomInt } from './math.js';
 
 const funcs = new WeakMap();
 
+export function getURLResolver({ base = document.baseURI, path = './' } = {}) {
+	const url = new URL(path, base).href;
+
+	return path => new URL(path, url).href;
+}
+
 /* global define */
 export function amd(name, factory, requires = {}) {
 	if (typeof define === 'function' && define.amd) {


### PR DESCRIPTION
Returns a function to easily get URLs relative to a given base URL. Useful for getting HTML templates & stylesheets relative to a custom elements script src.

```js
const resolveURL = getURLResolver({ base: 'https://cdn.example.com', path: '/components/' });
const tmp = await getHTML(resolveURL('./tmp.html'));
```
