### PR TITLE
Update various loaders

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -1,0 +1,1 @@
+export const REFERRER_POLICY = 'strict-origin-when-cross-origin';

--- a/disqus.js
+++ b/disqus.js
@@ -1,0 +1,69 @@
+import { createScript } from './dom.js';
+import { loaded } from './events.js';
+
+const TYPE = 'application/javascript';
+const REFERRER_POLICY = 'origin';
+const FETCH_PRIORITY = 'auto';
+export const ID = 'disqus_thread';
+
+export function getSiteURL(site) {
+	return new URL('/embed.js', `https://${site}.disqus.com/`).href;
+}
+
+export function getPreload(site, {
+	referrerPolicy = REFERRER_POLICY,
+	fetchPriority = FETCH_PRIORITY,
+} = {}) {
+	const link = document.createElement('link');
+	link.rel = 'preload';
+	link.as = 'script';
+	link.type = TYPE;
+	link.referrerPolicy = referrerPolicy;
+	link.fetchPriority = fetchPriority;
+	link.href = getSiteURL(site);
+
+	return link;
+}
+
+export function preload(site, {
+	referrerPolicy = REFERRER_POLICY,
+	fetchPriority = FETCH_PRIORITY,
+	parent = document.head,
+} = {}) {
+	const link = getPreload(site, { referrerPolicy, fetchPriority });
+	parent.append(link);
+}
+
+export function getScript(site, {
+	referrerPolicy = REFERRER_POLICY,
+	timestamp = Date.now(),
+	policy = null,
+	nonce = null,
+	type = TYPE,
+	noModule = false,
+	fetchPriority = FETCH_PRIORITY,
+} = {}) {
+	return createScript(getSiteURL(site), {
+		referrerPolicy, type, nonce, noModule,policy, fetchPriority, data: { timestamp },
+	});
+}
+
+export async function loadScript(site, {
+	referrerPolicy = REFERRER_POLICY,
+	timestamp = Date.now(),
+	policy = null,
+	nonce = null,
+	type = TYPE,
+	noModule = false,
+	fetchPriority = FETCH_PRIORITY,
+	parent = document.head,
+	signal,
+} = {}) {
+	const script = getScript(site, {
+		referrerPolicy, timestamp, policy, nonce, type, noModule, fetchPriority,
+	});
+
+	const promise = loaded(script, { signal });
+	parent.append(script);
+	return await promise;
+}

--- a/dom.js
+++ b/dom.js
@@ -1,8 +1,9 @@
 import { signalAborted } from './abort.js';
-import { addListener, listen } from './events.js';
+import { addListener, listen, loaded as whenLoaded } from './events.js';
 import { getDeferred, isAsync } from './promises.js';
 import { isHTML, isScriptURL, isTrustPolicy } from './trust.js';
 import { errorToEvent } from './utility.js';
+import { REFERRER_POLICY } from './defaults.js';
 
 export const readyStates = ['loading', 'interactive', 'complete'];
 
@@ -703,50 +704,26 @@ export function mutate(what, callback, options = {}) {
 	}
 }
 
+/**
+ * @Deprecated
+ */
 export async function scriptLoaded(script) {
-	const { resolve, reject, promise } = getDeferred();
-
-	if (! (script instanceof HTMLScriptElement)) {
-		reject(new TypeError('Expected a <script>'));
-	} else {
-		const controller = new AbortController();
-		const signal = controller.signal;
-
-		addListener(script, 'load', () => {
-			resolve();
-			controller.abort();
-		}, { signal });
-
-		addListener(script, 'error', () => {
-			reject(new DOMException(`Error loading <script src="${script.src}">`));
-			controller.abort();
-		}, { signal });
-
-		return promise;
-	}
+	console.warn('`scriptLoaded()` is deprecated. Use `loaded()` from `events.js` instead.');
+	/*
+	 * `loaded()` aliased as `whenLoaded()`
+	 */
+	return await whenLoaded(script);
 }
 
+/**
+ * @Deprecated
+ */
 export async function linkLoaded(link) {
-	const { resolve, reject, promise } = getDeferred();
-
-	if (! (link instanceof HTMLLinkElement)) {
-		reject(new TypeError('Expected a <link>'));
-	} else {
-		const controller = new AbortController();
-		const signal = controller.signal;
-
-		addListener(link, 'load', () => {
-			resolve();
-			controller.abort();
-		}, { signal });
-
-		addListener(link, 'error', () => {
-			reject(new DOMException(`Error loading <link src="${link.href}">`));
-			controller.abort();
-		}, { signal });
-
-		return promise;
-	}
+	console.warn('`linkLoaded()` is deprecated. Use `loaded()` from `events.js` instead.');
+	/*
+	 * `loaded()` aliased as `whenLoaded()`
+	 */
+	return await whenLoaded(link);
 }
 
 export function stripComments(node) {

--- a/dom.js
+++ b/dom.js
@@ -3,7 +3,6 @@ import { addListener, listen, loaded as whenLoaded } from './events.js';
 import { getDeferred, isAsync } from './promises.js';
 import { isHTML, isScriptURL, isTrustPolicy } from './trust.js';
 import { errorToEvent } from './utility.js';
-import { REFERRER_POLICY } from './defaults.js';
 
 export const readyStates = ['loading', 'interactive', 'complete'];
 

--- a/elements.js
+++ b/elements.js
@@ -1,0 +1,205 @@
+import { data, css } from './dom.js';
+
+export function createScript(src, {
+	async = true,
+	defer = false,
+	integrity = null,
+	nonce = null,
+	type = 'application/javascript',
+	crossOrigin = null,
+	referrerPolicy = REFERRER_POLICY,
+	noModule = false,
+	fetchPriority = 'auto',
+	data: dataset = {},
+	policy = null,
+} = {}) {
+	const script = document.createElement('script');
+	script.type = type;
+	script.noModule = noModule;
+	script.async = async;
+	script.defer = defer;
+	script.crossOrigin = crossOrigin;
+	script.referrerPolicy = referrerPolicy;
+	script.fetchPriority = fetchPriority;
+
+	if (typeof integrity === 'string') {
+		script.integrity = integrity;
+	}
+
+	if (typeof script === 'string') {
+		script.nonce = nonce;
+	}
+
+	data(script, dataset);
+
+	if (Object.is(policy, null) || !(policy.createScriptURL instanceof Function)) {
+		script.src = src;
+	} else {
+		script.src = policy.createScriptURL(src);
+	}
+
+	return script;
+}
+
+export function createImage(src, {
+	alt = '',
+	id = null,
+	height = undefined,
+	width = undefined,
+	crossOrigin = null,
+	itemprop = null,
+	itemtype = null,
+	itemscope = true,
+	sizes = null,
+	srcset = null,
+	referrerPolicy = REFERRER_POLICY,
+	fetchPriority = 'auto',
+	loading = 'eager',
+	decoding = 'async',
+	role = null,
+	slot = null,
+	part = [],
+	classList = [],
+	data: dataset = {},
+	styles = {},
+} = {}) {
+	const img = new Image(width, height);
+	img.alt = alt;
+	img.referrerPolicy = referrerPolicy;
+	img.loading = loading;
+	img.decoding = decoding;
+	img.fetchPriority = fetchPriority;
+
+	if (typeof id === 'string') {
+		img.id = id;
+	}
+
+	if (typeof role === 'string') {
+		img.role = role;
+	}
+
+	if (typeof crossOrigin === 'string') {
+		img.crossOrigin = crossOrigin;
+	}
+
+	if (typeof itemprop === 'string') {
+		img.setAttribute('itemprop', itemprop);
+	}
+
+	if (typeof itemtype === 'string') {
+		img.setAttribute('itemtype', new URL(itemtype, 'https://schema.org/').href);
+		img.toggleAttribute('itemscope', itemscope);
+	}
+
+	if (typeof slot === 'string') {
+		img.slot = slot;
+	}
+
+	if (Array.isArray(part) && part.length !== 0 && 'part' in img) {
+		img.part.add(...part);
+	}
+
+	if (Array.isArray(classList) && classList.length !== 0) {
+		img.classList.add(...classList);
+	}
+
+	if (typeof srcset === 'object' && srcset !== null) {
+		img.srcset = Object.entries(srcset).map(([size, src]) => `${src} ${size}`).join(', ');
+	} else if (Array.isArray(srcset) && srcset.length !== 0) {
+		img.srcset = srcset.join(', ');
+	} else if (typeof srcset === 'string') {
+		img.srcset = srcset;
+	}
+
+	if (Array.isArray(sizes) && sizes.length !== 0) {
+		img.sizes = sizes.join(', ');
+	} else if (typeof sizes === 'string') {
+		img.sizes = sizes;
+	}
+
+	data([img], dataset);
+	css([img], styles);
+
+	if (typeof src === 'string' && src.length !== 0) {
+		img.src = src;
+	} else if (src instanceof URL) {
+		img.src = url.href;
+	}
+
+	return img;
+}
+
+export function createLink(href = null, {
+	rel = [],
+	type = null,
+	as = null,
+	crossOrigin = 'anonymous',
+	referrerPolicy = 'no-referrer',
+	fetchPriority = 'auto',
+	integrity = null,
+	nonce = null,
+	media = 'all',
+	disabled = false,
+	title = null,
+	sizes = [],
+}) {
+	const link = document.createElement('link');
+
+	if (Array.isArray(rel)) {
+		link.relList.add(...rel);
+	} else if (typeof rel === 'string') {
+		link.relList.add(rel);
+	}
+
+	if (typeof type === 'string') {
+		link.type = type;
+	}
+
+	if (typeof as === 'string') {
+		link.as = as;
+	}
+
+	if (typeof crossOrigin === 'string') {
+		link.crossOrigin = crossOrigin;
+	}
+
+	if (typeof referrerPolicy === 'string') {
+		link.referrerPolicy = referrerPolicy;
+	}
+
+	if (typeof fetchPriority === 'string') {
+		link.fetchPriority = fetchPriority;
+	}
+
+	if (typeof integrity === 'string') {
+		link.integrity = integrity;
+	}
+
+	if (typeof nonce === 'string') {
+		link.nonce = nonce;
+	}
+
+	if (typeof media === 'string') {
+		link.media = media;
+	}
+
+	if (typeof href === 'string') {
+		link.href = href;
+	}
+
+	if (disabled) {
+		link.disabled = true;
+	}
+
+	if (typeof title === 'string') {
+		link.title = title;
+	}
+
+	if (Array.isArray(sizes) && sizes.length !== 0) {
+		link.sizes.add(...sizes);
+	} else if (typeof sizes === 'string') {
+		link.sizes.add(sizes);
+	}
+
+	return link;
+}

--- a/elements.js
+++ b/elements.js
@@ -1,4 +1,5 @@
 import { data, css } from './dom.js';
+import { REFERRER_POLICY } from './defaults.js';
 
 export function createScript(src, {
 	async = true,
@@ -123,7 +124,7 @@ export function createImage(src, {
 	if (typeof src === 'string' && src.length !== 0) {
 		img.src = src;
 	} else if (src instanceof URL) {
-		img.src = url.href;
+		img.src = src.href;
 	}
 
 	return img;

--- a/events.js
+++ b/events.js
@@ -26,7 +26,7 @@ export async function loaded(target, {
 			 * <img loading="lazy"> will not load until appended
 			 */
 			resolve(target);
-		} else if (target instanceof HTMLImageElement && img.decode instanceof Function) {
+		} else if (target instanceof HTMLImageElement && target.decode instanceof Function) {
 			await target.decode();
 			return target;
 		} else {

--- a/loader.js
+++ b/loader.js
@@ -1,5 +1,4 @@
-import { getDeferred } from './promises.js';
-import { listen, loaded } from './events.js';
+import { loaded } from './events.js';
 import { createScript, createImage, createLink } from './elements.js';
 
 /**
@@ -122,7 +121,7 @@ export async function loadStylesheet(href, {
 		title, nonce,
 	});
 
-	const promise = loaded(link);
+	const promise = loaded(link, { signal });
 
 	parent.append(link);
 


### PR DESCRIPTION
- Add module for creating specific types of elements
- Use a standardized async `loaded()` for scripts, imgs, etc
- Add module for loading Disqus comments script
- Deprecate certain old loading funcs in `dom.js`