### PR TITLE
Add `resizeImageFile()` to `img-utils.js`

### DIFF
--- a/img-utils.js
+++ b/img-utils.js
@@ -1,14 +1,83 @@
 import { getDeferred } from './promises.js';
 import { createImage, createElement } from './elements.js';
 
-export async function canvasToFile(canvas, { type = 'image/jpeg', quality = 0.8, name } = {}) {
+export const EXTENSIONS = {
+	'image/jpeg': '.jpg',
+	'image/png': '.png',
+	'image/webp': '.webp',
+};
+
+const DEFAULT_TYPE = 'image/jpeg';
+const DEFAULT_QUALITY = 0.8;
+const DEFAULT_HEIGHT = 480;
+
+export const supportsType = type => type.toLowerCase() in EXTENSIONS;
+export const getExtensionForType = type => EXTENSIONS[type.toLowerCase()];
+
+export async function resizeImageFile(file, {
+	type    = DEFAULT_TYPE,
+	quality = DEFAULT_QUALITY,
+	height  = DEFAULT_HEIGHT,
+	x = 0,
+	y = 0,
+} = {}) {
+	const { resolve, reject, promise } = getDeferred();
+	const img = await fileToImage(file);
+	const { naturalWidth, naturalHeight } = img;
+	const width = naturalWidth * (height / naturalHeight);
+
+	if (! (file instanceof File) || ! file.type.startsWith('image/')) {
+		reject(new TypeError('Not an image file'));
+	} else if (typeof height !== 'number' || height < 1 || Number.isNaN(height)) {
+		reject(new TypeError('Height is not an integer'));
+	} else if (! supportsType(type)) {
+		reject(new TypeError(`Unsupported type: ${type}`));
+	} else if ('OffscreenCanvas' in globalThis) {
+		const canvas = new globalThis.OffscreenCanvas(width, height);
+		const ctx = canvas.getContext('2d');
+
+		ctx.imageSmoothingEnabled = false;
+		ctx.drawImage(img, x, y, width, height);
+
+		const blob = await canvas.convertToBlob({ type, quality });
+		const basename = file.name.split('.')[0];
+		const ext = getExtensionForType(blob.type);
+		const f = new File([blob], `${basename}${ext}`, { type: blob.type });
+		URL.revokeObjectURL(img.src);
+		resolve(f);
+	} else {
+		const canvas = document.createElement('canvas');
+		canvas.width = width;
+		canvas.height = height;
+		const ctx = canvas.getContext('2d');
+
+		ctx.imageSmoothingEnabled = false;
+		ctx.drawImage(img, x, y, width, height);
+
+		const f = await canvasToFile(canvas, { type, quality, name: file.name });
+		URL.revokeObjectURL(img.src);
+		resolve(f);
+	}
+
+	return await promise;
+}
+
+export async function canvasToFile(canvas, {
+	type    = DEFAULT_TYPE,
+	quality = DEFAULT_QUALITY,
+	name    = 'canvas-img',
+} = {}) {
 	const { resolve, reject, promise } = getDeferred();
 
 	if (! (canvas instanceof HTMLCanvasElement)) {
 		reject(new DOMException('Expected a <canvas> element'));
+	} else if (! supportsType(type)) {
+		throw new TypeError(`Unsupported type: ${type}`);
 	} else {
 		canvas.toBlob(blob => {
-			const file = new File([blob], name, { type: blob.type });
+			const basename = name.split('.')[0];
+			const ext = getExtensionForType(blob.type);
+			const file = new File([blob], `${basename}${ext}`, { type: blob.type });
 			resolve(file);
 		}, type, quality);
 	}

--- a/test/index.html
+++ b/test/index.html
@@ -24,7 +24,7 @@
 			child-src 'none';
 			frame-ancestors 'none';
 			connect-src 'self' cdn.kernvalley.us api.github.com/users/ api.pwnedpasswords.com/range/ maps.kernvalley.us/places/ events.kernvalley.us/events.json;
-			img-src 'self' cdn.kernvalley.us avatars.githubusercontent.com/u/ gravatar.com/avatar/;
+			img-src * data: blob:;
 			require-trusted-types-for 'script';
 			trusted-types default empty#html empty#script sanitizer#html fetch#html loader#html loader#script-url;
 			upgrade-insecure-requests;"


### PR DESCRIPTION
Also adds some helper methods and consts.

Updates CSP to allow `data:` & `blob:` URIs for image.
