### PR TITLE
Update use of call-once functions

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -3,7 +3,7 @@ import { addListener, listen, loaded as whenLoaded } from './events.js';
 import { getDeferred, isAsync } from './promises.js';
 import { isHTML, isTrustPolicy } from './trust.js';
 import { HTML } from './types.js';
-import { errorToEvent } from './utility.js';
+import { errorToEvent, callOnce } from './utility.js';
 import { data as setData, css as setCss, attr as setAttr } from './attrs.js';
 
 export const readyStates = ['loading', 'interactive', 'complete'];
@@ -395,7 +395,7 @@ export async function when(what, events, { capture, passive, signal, base } = {}
 	return promise;
 }
 
-export async function ready({ signal } = {}) {
+export const ready = callOnce(async function ready({ signal } = {}) {
 	const { promise, resolve, reject } = getDeferred();
 
 	if (signal instanceof AbortSignal && signal.aborted) {
@@ -414,7 +414,7 @@ export async function ready({ signal } = {}) {
 	}
 
 	return promise;
-}
+});
 
 export async function whenReadyState(state, { signal } = {}) {
 	const { resolve, reject, promise } = getDeferred();
@@ -455,15 +455,15 @@ export async function whenReadyState(state, { signal } = {}) {
 	return promise;
 }
 
-export async function interactive({ signal } = {}) {
+export const interactive =  callOnce(async function interactive({ signal } = {}) {
 	await whenReadyState('interactive', { signal });
-}
+});
 
-export async function complete({ signal } = {}) {
+export const complete = callOnce(async function complete({ signal } = {}) {
 	await whenReadyState('complete', { signal });
-}
+});
 
-export async function loaded({ signal } = {}) {
+export const loaded =  callOnce(async function loaded({ signal } = {}) {
 	const { promise, resolve, reject } = getDeferred();
 
 	if (signal instanceof AbortSignal && signal.aborted) {
@@ -482,19 +482,35 @@ export async function loaded({ signal } = {}) {
 	}
 
 	return promise;
-}
+});
 
-export async function unloaded({ signal } = {}) {
+export const unloaded = callOnce(async function unloaded({ signal } = {}) {
 	const { promise, resolve } = getDeferred();
 	listen(globalThis, 'unload', resolve, { signal, once: true, capture: true });
 	return promise;
-}
+});
 
-export async function beforeUnload({ signal } = {}) {
+export const beforeUnload = callOnce(async function beforeUnload({ signal } = {}) {
 	const { promise, resolve } = getDeferred({ signal });
 	listen(globalThis, 'beforeunload', resolve, { signal, once: true, capture: true });
 	return promise;
-}
+});
+
+export const beforeInstallPrompt = callOnce(async function({ signal } = {}) {
+	const { promise, resolve, reject } = getDeferred();
+
+	if (signal instanceof AbortSignal && signal.aborted) {
+		reject(signal.reason);
+	} else if ('onbeforeinstallprompt' in globalThis) {
+		listen(globalThis, 'beforeinstallprompt', resolve, { once: true, capture: true, signal });
+
+		if (signal instanceof AbortSignal) {
+			listen(signal, 'abort', ({ reason }) => rejcet(reason), { once: true });
+		}
+	}
+
+	return await promise;
+});
 
 export async function whenPageVisible({ signal } = {}) {
 	const { promise, resolve } = getDeferred({ signal });

--- a/dom.js
+++ b/dom.js
@@ -505,7 +505,7 @@ export const beforeInstallPrompt = callOnce(async function({ signal } = {}) {
 		listen(globalThis, 'beforeinstallprompt', resolve, { once: true, capture: true, signal });
 
 		if (signal instanceof AbortSignal) {
-			listen(signal, 'abort', ({ reason }) => rejcet(reason), { once: true });
+			listen(signal, 'abort', ({ reason }) => reject(reason), { once: true });
 		}
 	}
 

--- a/http.js
+++ b/http.js
@@ -1,6 +1,6 @@
 import { parse, loaded } from './dom.js';
 import { signalAborted } from './abort.js';
-import { setURLParams, setUTMParams, isObject, isNullish } from './utility.js';
+import { setURLParams, setUTMParams, isObject, isNullish, callOnce } from './utility.js';
 import { createPolicy } from './trust.js';
 import { HTTPException } from './HTTPException.js';
 import * as TYPES from './types.js';
@@ -302,10 +302,10 @@ export async function submitForm(form) {
 	}
 }
 
-export async function getManifest({ timeout, signal } = {}) {
+export const getManifest = callOnce(async function getManifest({ timeout, signal } = {}) {
 	const resp = await getLink('link[rel="manifest"][href]', { timeout, signal });
 	return await resp.json();
-}
+});
 
 export async function getLink(link, { timeout, signal } = {}) {
 	if (typeof link === 'string') {

--- a/promises.js
+++ b/promises.js
@@ -1,28 +1,19 @@
-import { when, ready, loaded, beforeUnload, unloaded } from './dom.js';
+import { when, ready, loaded, beforeInstallPrompt } from './dom.js';
 import { signalAborted } from './abort.js';
 import { getManifest } from './http.js';
 import { listen, onKeypress } from './events.js';
 import { checkSupport as locksSupported } from './LockManager.js';
-
 export const infinitPromise = new Promise(() => {});
 
 export const readyPromise = ready();
 
 export const loadedPromise = loaded();
 
-export const unloadPromise = unloaded();
-
-export const beforeUnloadPromise = beforeUnload();
-
 export const manifestPromise = new Promise((resolve, reject) => {
 	readyPromise.then(() => getManifest()).then(resolve).catch(reject);
 });
 
-export const beforeInstallPromptPromise = new Promise(resolve => {
-	if ('onbeforeinstallprompt' in globalThis) {
-		globalThis.addEventListener('beforeinstallprompt', resolve, { once: true, capture: true });
-	}
-});
+export const beforeInstallPromptPromise = beforeInstallPrompt();
 
 export function isAsyncFunction(what) {
 	return what instanceof Function && what.constructor.name === 'AsyncFunction';

--- a/shims/function.js
+++ b/shims/function.js
@@ -5,16 +5,23 @@ if (! (Function.prototype.once instanceof Function)) {
 	 * @see https://github.com/tc39/proposal-function-once
 	 */
 	Function.prototype.once = function once(thisArg) {
-		const callback = (...args) => {
+		const callback = this;
+		return function(...args) {
 			if (funcs.has(callback)) {
 				return funcs.get(callback);
-			} else {
-				const retVal = this.apply(thisArg || this, args);
+			} else if (callback.constructor.name === 'AsyncFunction') {
+				const retVal = callback.apply(thisArg || callback, args).catch(err => {
+					funcs.delete(callback);
+					throw err;
+				});
+
+				funcs.set(callback, retVal);
+				return retVal;
+			} else if (callback instanceof Function) {
+				const retVal = callback.apply(thisArg || callback, args);
 				funcs.set(callback, retVal);
 				return retVal;
 			}
 		};
-
-		return callback;
 	};
 }


### PR DESCRIPTION
- Update `Function.prototype.once` shim
- Update `callOnce` in `utility.js`
- Remove Promise consts for `beforeunload` & `unload` events
- Wrap all load/ready/complete/etc functions that are single event