### PR TITLE
Update use of Sanitizer & TrustedTypes API

### DIFF
--- a/elements.js
+++ b/elements.js
@@ -203,6 +203,7 @@ export function createElement(tag, {
 export function createScript(src, {
 	async = true,
 	defer = false,
+	blocking = null,
 	integrity = null,
 	nonce = null,
 	type = JS,
@@ -242,6 +243,12 @@ export function createScript(src, {
 
 	if (typeof nonce === 'string') {
 		script.nonce = nonce;
+	}
+
+	if (Array.isArray(blocking)) {
+		script.setAttribute('blocking', blocking.join(' '));
+	} else if (typeof blocking === 'string') {
+		script.setAttribute('blocking', blocking);
 	}
 
 	if (isTrustPolicy(policy)) {
@@ -340,6 +347,7 @@ export function createLink(href = null, {
 	rel = [],
 	type = null,
 	as = null,
+	blocking = null,
 	crossOrigin = 'anonymous',
 	referrerPolicy = 'no-referrer',
 	fetchPriority = 'auto',
@@ -394,6 +402,12 @@ export function createLink(href = null, {
 
 	if (typeof media === 'string') {
 		link.media = media;
+	}
+
+	if (Array.isArray(blocking)) {
+		link.setAttribute('blocking', blocking.join(' '));
+	} else if (typeof blocking === 'string') {
+		link.setAttribute('blocking', blocking);
 	}
 
 	if (typeof href === 'string') {

--- a/loader.js
+++ b/loader.js
@@ -76,6 +76,7 @@ export async function prerender(href, { signal } = {}) {
 export async function loadScript(src, {
 	async = true,
 	defer = false,
+	blocking = null,
 	noModule = false,
 	type = JS,
 	crossOrigin = 'anonymous',
@@ -96,7 +97,7 @@ export async function loadScript(src, {
 		const controller = new AbortController();
 		const script = createScript(src, {
 			async, defer, noModule, type, crossOrigin, referrerPolicy, integrity,
-			nonce, fetchPriority, policy, dataset: data,
+			nonce, fetchPriority, policy, dataset: data, blocking,
 			events: {
 				load: ({ target }) => {
 					resolve(target);
@@ -140,6 +141,7 @@ export async function loadScript(src, {
 export async function loadStylesheet(href, {
 	rel = 'stylesheet',
 	media = 'all',
+	blocking = null,
 	crossOrigin = 'anonymous',
 	referrerPolicy = 'no-referrer',
 	integrity = null,
@@ -159,7 +161,7 @@ export async function loadStylesheet(href, {
 
 		const link = await createLink(href, {
 			rel, media, crossOrigin, referrerPolicy, integrity, disabled, fetchPriority,
-			title, nonce,
+			title, nonce, blocking,
 			events: {
 				load: ({ target }) => {
 					resolve(target);

--- a/sanitizerUtils.js
+++ b/sanitizerUtils.js
@@ -1,4 +1,5 @@
 import { createHTML } from './SanitizerBase.js';
+
 export const supported = () => 'Sanitizer' in globalThis;
 export const nativeSupport = supported();
 
@@ -6,19 +7,22 @@ export function getSantizerUtils(Sanitizer, defaultConfig) {
 	const setHTML = function setHTML(el, input, { sanitizer = new Sanitizer() } = {}) {
 		const tmp = document.createElement('template');
 		tmp.innerHTML = createHTML(input);
-		el.replaceChildren(sanitizer.sanitize(tmp.content));
+		sanitizer.sanitize(tmp.content);
+		el.replaceChildren(tmp.content);
 	};
 
 	const polyfill = function polyfill() {
 		let polyfilled = false;
-		if (! ('Sanitizer' in globalThis)) {
+		if (! supported()) {
 			globalThis.Sanitizer = Sanitizer;
 			polyfilled = true;
 		} else {
 			if (! (globalThis.Sanitizer.prototype.sanitizeFor instanceof Function)) {
 				globalThis.Sanitizer.prototype.sanitizeFor = function(element, input) {
 					const el = document.createElement(element);
-					el.setHTML(input, { sanitizer: this });
+					const tmp = document.createElement('template');
+					tmp.innerHTML = createHTML(input);
+					el.append(this.sanitize(tmp.content));
 					return el;
 				};
 			}

--- a/test/index.js
+++ b/test/index.js
@@ -11,10 +11,18 @@ import { description, keywords, robots, thumbnail } from '../meta.js';
 import { SanitizerConfig as sanitizerConfig } from '../SanitizerConfig.js';
 import { createPolicy } from '../trust.js';
 
-const sanitizer = new Sanitizer(sanitizerConfig);
+const sanitizer = new Sanitizer({
+	...sanitizerConfig,
+	allowCustomElements: true,
+	allowElements: [...sanitizerConfig.allowElements, 'krv-ad'],
+	allowAttributes: { ...sanitizerConfig.allowAttributes, 'url': ['krv-ad'] },
+});
+globalThis.sanitizer = sanitizer;
 
 createPolicy('default', {
 	createHTML: input => sanitizer.sanitizeFor('div', input).innerHTML,
+	createScriptURL: input => input,
+	createScript: () => globalThis.trustedTypes.emptyScript,
 });
 
 keywords(['javascript', 'ecmascript', 'es6', 'modules', 'library']);


### PR DESCRIPTION
- Update polyfill for Sanitizer API
- Add `html` to `createElement()`
- Support `TrustedHTML` & `Sanitizer` in `createElement()`
- Deprecate `html()` in `dom.js` - alias to `createElement()`
- Update `loadScript()`, `loadStylesheet()` & `loadImage()` in `loader.js`
- Support `blocking` in `<script>`s & `<link>`s