### PR TITLE
Implement setting of trusted properties

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,6 +35,11 @@
       "cookieStore": "readonly",
       "globalThis": "readonly",
       "Iterator": "readonly",
-      "scheduler": "readonly"
+      "scheduler": "readonly",
+      "trustedTypes": "readonly",
+      "TrustedHTML": "readonly",
+      "TrustedScript": "readonly",
+      "TrustedScriptURL": "readonly",
+      "TrustedTypePolicy": "readonly"
     }
 }

--- a/TrustedTypes.js
+++ b/TrustedTypes.js
@@ -359,10 +359,9 @@ export class TrustedTypeFactory extends EventTarget {
 	 * @return {String}          [description]
 	 */
 	getPropertyType(tagName, property/*, elementNS*/) {
-		property = property.toLowerCase();
 		tagName = tagName.toLowerCase();
 
-		if (events.includes(property)) {
+		if (events.includes(property.toLowerCase())) {
 			return TrustedScript.name;
 		}
 
@@ -378,9 +377,9 @@ export class TrustedTypeFactory extends EventTarget {
 			case 'script': {
 				if (property === 'src') {
 					return TrustedScriptURL.name;
-				} else if (['text', 'innerText', 'textContent'].includes(property)) {
+				} else if (['text', 'innerText', 'textContent', 'innerHTML'].includes(property)) {
 					return TrustedScript.name;
-				} else if (['outerHTML', 'innerHTML'].includes(property)) {
+				} else if (['outerHTML'].includes(property)) {
 					return TrustedHTML.name;
 				} else {
 					return null;
@@ -389,7 +388,7 @@ export class TrustedTypeFactory extends EventTarget {
 
 			default: {
 				if (['innerHTML', 'outerHTML'].includes(property)) {
-					return 'TrustedHTML';
+					return TrustedHTML.name;
 				} else {
 					return null;
 				}
@@ -450,7 +449,6 @@ export const trustedTypes = new TrustedTypeFactory(symbols.trustedKey);
 
 /**
  * [polyfill description]
- * @param  {Boolean} [enableHarden=false]               [description]
  * @return {[type]}                       [description]
  */
 export function polyfill() {

--- a/attrs.js
+++ b/attrs.js
@@ -1,44 +1,6 @@
 import { clamp, between } from './math.js';
 import { isObject } from './utility.js';
-import { isScriptURL, getAttributeType, createScriptURL, createScript, createHTML } from './trust.js';
-
-export function setAttr(el, attr, val, {
-	elementNs,
-	policy,
-} = {}) {
-	switch(getAttributeType(el.tagName.toLowerCase(), attr, elementNs)) {
-		case 'TrustedScriptURL':
-			if (typeof elementNs === 'string') {
-				el.setAttributeNs(elementNs, attr, createScriptURL(val, { policy }));
-			} else {
-				el.setAttribute(attr, createScriptURL(val, { policy }));
-			}
-			break;
-
-		case 'TrustedScript':
-			if (typeof elementNs === 'string') {
-				el.setAttributeNS(elementNs, attr, createScript(val, { policy }));
-			} else {
-				el.setAttribute(attr, createScript(val, { policy }));
-			}
-			break;
-
-		case 'TrustedHTML':
-			if (typeof elementNs === 'string') {
-				el.setAttributeNS(elementNs, attr, createHTML(val, { policy }));
-			} else {
-				el.setAttribute(attr, createHTML(val, { policy }));
-			}
-			break;
-
-		default:
-			if (typeof elementNs === 'string') {
-				el.setAttributeNS(elementNs, attr, val);
-			} else {
-				el.setAttribute(attr, val);
-			}
-	}
-}
+import { setAttr, isScriptURL } from './trust.js';
 
 export function getAttrs(el) {
 	if (typeof el === 'string') {
@@ -257,3 +219,5 @@ export function setURL(el, attr, val, {
 		el.removeAttribute(attr);
 	}
 }
+
+export { setAttr };

--- a/elements.js
+++ b/elements.js
@@ -1,7 +1,7 @@
 import { data, attr, css, getAttrs } from './attrs.js';
 import { listen } from './events.js';
 import { getDeferred } from './promises.js';
-import { isTrustPolicy, isHTML } from './trust.js';
+import { setProp } from './trust.js';
 import { REFERRER_POLICY } from './defaults.js';
 import { isObject, isNullish } from './utility.js';
 import { JS } from './types.js';
@@ -138,10 +138,8 @@ export function createElement(tag, {
 				&& Element.prototype.setHTML instanceof Function
 			) {
 				el.setHTML(html, { sanitizer });
-			} else if (isTrustPolicy(policy) && ! isHTML(html)) {
-				el.innerHTML = policy.createHTML(html);
 			} else {
-				el.innerHTML = html;
+				setProp(el, 'innerHTML', html, { policy });
 			}
 		}
 
@@ -251,11 +249,7 @@ export function createScript(src, {
 		script.setAttribute('blocking', blocking);
 	}
 
-	if (isTrustPolicy(policy)) {
-		script.src = policy.createScriptURL(src);
-	} else {
-		script.src = src;
-	}
+	setProp(script, 'src', src, { policy });
 
 	return script;
 }
@@ -520,27 +514,15 @@ export function createIframe(src, {
 	}
 
 	if (typeof srcdoc === 'string' && srcdoc.length !== 0) {
-		if (isTrustPolicy(policy) && ! isHTML(srcdoc)) {
-			iframe.srcdoc = policy.createHTML(srcdoc);
-		} else {
-			iframe.srcdoc = srcdoc;
-		}
+		setProp(iframe, 'srcdoc', srcdoc, { policy });
 	} else if (srcdoc instanceof Document) {
-		if (isTrustPolicy(policy)) {
-			iframe.srcdoc = policy.createHTML(srcdoc.documentElement.outerHTML.replace(/\n/g, ''));
-		} else {
-			iframe.srcdoc = srcdoc.documentElement.outerHTML.replace(/\n/g, '');
-		}
+		setProp(iframe, 'srcdoc'. srcdoc.documentElement.outerHTML.replace(/\n/g, ''), { policy });
 	}
 
 	if (typeof src === 'string' || src instanceof URL) {
 		iframe.src = src;
 	} else if (src instanceof Document) {
-		if (isTrustPolicy(policy)) {
-			iframe.srcdoc = policy.createHTML(src.documentElement.outerHTML.replace(/\n/g, ''));
-		} else {
-			iframe.srcdoc = src.documentElement.outerHTML.replace(/\n/g, '');
-		}
+		setProp(iframe, 'srcdoc'. src.documentElement.outerHTML.replace(/\n/g, ''), { policy });
 	}
 
 	return iframe;


### PR DESCRIPTION
In addition to previous work on trusted attributes. Things like setting `script.src = val` via `setProp(script, 'src', val)` are now supported and more secure.

Also makes `trustedTypes` a global.