### PR TITLE
Fully (?) harden

### DIFF
--- a/TrustedTypes.js
+++ b/TrustedTypes.js
@@ -88,7 +88,7 @@ class TrustedType {
 	 * @return {String} [description]
 	 */
 	toString() {
-		return this[symbols.trustedValue];
+		return this.valueOf();
 	}
 
 	/**
@@ -96,6 +96,10 @@ class TrustedType {
 	 * @return {String} [description]
 	 */
 	toJSON() {
+		return this.valueOf();
+	}
+
+	valueOf() {
 		return this[symbols.trustedValue];
 	}
 }
@@ -342,6 +346,8 @@ export class TrustedTypeFactory extends EventTarget {
 			case 'iframe': {
 				if (attribute === 'srcdoc') {
 					return TrustedHTML.name;
+				} else if (attribute === 'src') {
+					return TrustedScriptURL.name;
 				} else {
 					return null;
 				}
@@ -366,7 +372,8 @@ export class TrustedTypeFactory extends EventTarget {
 		}
 
 		switch(tagName) {
-			case 'embed': {
+			case 'embed':
+			case 'iframe': {
 				if (property === 'src') {
 					return 'TrustedScriptURL';
 				} else {

--- a/disqus.js
+++ b/disqus.js
@@ -1,10 +1,22 @@
 import { createScript } from './elements.js';
 import { loaded } from './events.js';
+import { createPolicy } from './trust.js';
+
+const disqusPolicy = createPolicy('disqus#script', {
+	createScriptURL: input => {
+		if (input.endsWith('.disqus.com/embed.js')) {
+			return input;
+		} else {
+			throw new TypeError(`${input} is not a valid Disqus script URL`);
+		}
+	}
+});
 
 const TYPE = 'application/javascript';
 const REFERRER_POLICY = 'origin';
 const FETCH_PRIORITY = 'auto';
 export const ID = 'disqus_thread';
+export const trustPolicies = [disqusPolicy.name];
 
 export function getSiteURL(site) {
 	return new URL('/embed.js', `https://${site}.disqus.com/`).href;
@@ -37,21 +49,21 @@ export function preload(site, {
 export function getScript(site, {
 	referrerPolicy = REFERRER_POLICY,
 	timestamp = Date.now(),
-	policy = null,
+	policy = disqusPolicy,
 	nonce = null,
 	type = TYPE,
 	noModule = false,
 	fetchPriority = FETCH_PRIORITY,
 } = {}) {
 	return createScript(getSiteURL(site), {
-		referrerPolicy, type, nonce, noModule,policy, fetchPriority, dataset: { timestamp },
+		referrerPolicy, type, nonce, noModule, policy, fetchPriority, dataset: { timestamp },
 	});
 }
 
 export async function loadScript(site, {
 	referrerPolicy = REFERRER_POLICY,
 	timestamp = Date.now(),
-	policy = null,
+	policy = disqusPolicy,
 	nonce = null,
 	type = TYPE,
 	noModule = false,

--- a/dom.js
+++ b/dom.js
@@ -637,4 +637,3 @@ export function createTable(data, { caption, header, footer } = {}) {
 }
 
 export { addListener, isAsync, errorToEvent };
-

--- a/elements.js
+++ b/elements.js
@@ -520,7 +520,7 @@ export function createIframe(src, {
 	}
 
 	if (typeof src === 'string' || src instanceof URL) {
-		iframe.src = src;
+		setProp(iframe, 'src', src.toString(), { policy });
 	} else if (src instanceof Document) {
 		setProp(iframe, 'srcdoc'. src.documentElement.outerHTML.replace(/\n/g, ''), { policy });
 	}

--- a/krv/embed.js
+++ b/krv/embed.js
@@ -1,4 +1,6 @@
 import { createIframe } from '../elements.js';
+import { policy, trustedURLs, trustPolicies } from './policy.js';
+
 
 export function createKRVMaps({
 	width, height, markers = [], loading = 'lazy', locate, fullscreen,
@@ -7,7 +9,7 @@ export function createKRVMaps({
 	fetchPriority = 'auto', title, id, classList, referrerPolicy = 'no-referrer',
 	styles, dataset, slot, part,
 } = {}) {
-	const src = new URL('https://maps.kernvalley.us/embed');
+	const src = new URL(trustedURLs.maps);
 	const allow = [];
 	const sandbox = ['allow-scripts', 'allow-popups'];
 
@@ -63,9 +65,9 @@ export function createKRVMaps({
 		src.searchParams.set('tiles', tiles);
 	}
 
-	return createIframe(src, {
+	return createIframe(src.href, {
 		height, width, referrerPolicy, loading, title, classList, id,
-		fetchPriority, allow, sandbox, styles, dataset, slot, part,
+		fetchPriority, allow, sandbox, styles, dataset, slot, part, policy,
 	});
 }
 
@@ -74,7 +76,7 @@ export function createKRVEvents({
 	fetchPriority = 'auto', title, id, classList, referrerPolicy = 'no-referrer',
 	styles, dataset, slot, part,
 } = {}) {
-	const src = new URL('https://events.kernvalley.us/embed/');
+	const src = new URL(trustedURLs.events);
 
 	if (typeof theme === 'string') {
 		src.searchParams.set('t', theme);
@@ -84,9 +86,10 @@ export function createKRVEvents({
 		src.searchParams.set('s', source);
 	}
 
-	return createIframe(src, {
-		height, width, referrerPolicy, title, id, classList, fetchPriority, loading,
-		sandbox: ['allow-scripts', 'allow-popups'], styles, dataset, slot, part,
+	return createIframe(src.href, {
+		height, width, referrerPolicy, title, id, classList, fetchPriority,
+		loading, policy, sandbox: ['allow-scripts', 'allow-popups'], styles,
+		dataset, slot, part,
 	});
 }
 
@@ -95,7 +98,7 @@ export function createWFDEvents({
 	fetchPriority = 'auto', title, id, classList, referrerPolicy = 'no-referrer',
 	styles, dataset, slot, part,
 } = {}) {
-	const src = new URL('https://whiskeyflatdays.com/embed/');
+	const src = new URL(trustedURLs.wfdEvents.href);
 
 	if (typeof theme === 'string') {
 		src.searchParams.set('theme', theme);
@@ -109,8 +112,11 @@ export function createWFDEvents({
 		src.searchParams.set('images', '');
 	}
 
-	return createIframe(src, {
-		height, width, referrerPolicy, fetchPriority, loading, title, classList, id,
-		sandbox: ['allow-scripts', 'allow-popups'], styles, dataset, slot, part,
+	return createIframe(src.href, {
+		height, width, referrerPolicy, fetchPriority, loading, title, classList,
+		id, policy, sandbox: ['allow-scripts', 'allow-popups'], styles, dataset,
+		slot, part,
 	});
 }
+
+export { trustPolicies };

--- a/krv/policy.js
+++ b/krv/policy.js
@@ -1,0 +1,23 @@
+import { createPolicy } from '../trust.js';
+
+export const trustedURLs = {
+	maps: new URL('/embed', 'https://maps.kernvalley.us'),
+	events: new URL('/embed/', 'https://events.kernvalley.us'),
+	wfdEvents: new URL('/embed/', 'https://whiskeyflatdays.com'),
+};
+
+export const policy = createPolicy('krv#embed', {
+	createScriptURL: input => {
+		const url = new URL(input, document.baseURI);
+
+		if (Object.values(trustedURLs).some(
+			known => url.origin === known.origin && url.pathname.startsWith(known.pathname))
+		) {
+			return url.href;
+		} else {
+			throw new TypeError(`Unknown KRV embed source: ${input}`);
+		}
+	}
+});
+
+export const trustPolicies = [policy.name];


### PR DESCRIPTION
- Require `TrustedScriptURL` for `<iframe src>`
- "harden" full list of "injection sinks" mentioned in proposal (`eval`, `new Function()`, `setTimeout()`, etc)
- WIP implementing trust policies e.g. for KRV Embeds & Disqus script (not sure about the `<iframe>`)