### PR TITLE
Relase/2.7.1 (Integrate support for `TrustedTypes`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.7.1] - 2023-03-03
+### Added
+- Add handling of `Trusted*` in addition to strings
+- Add support for `TrustedHTML` in `elements.js` & `dom.js`
+- Add `isTrustedType` to `trusts.js`
+
+### Changed
+- Avoid converting attributes to strings or URLs
+- Provide a set of trust policies
+- Update `youtube.js` to use its own policy
+- Do not require parent node when sanitizing nodes
+- Update creation of various elements
+- A whole chain of passing trusted types along instead of converting
+
 ## [v2.7.0] - 2023-02-06
 
 ### Changed

--- a/TrustedTypes.js
+++ b/TrustedTypes.js
@@ -463,6 +463,10 @@ export function polyfill() {
 		globalThis.TrustedTypePolicy = TrustedTypePolicy;
 	}
 
+	if (! ('TrustedType' in globalThis)) {
+		globalThis.TrustedType = TrustedType;
+	}
+
 	if (! ('TrustedHTML' in globalThis)) {
 		globalThis.TrustedHTML = TrustedHTML;
 	}

--- a/dom.js
+++ b/dom.js
@@ -227,8 +227,10 @@ export function html(what, text, {
 	sanitizer,
 	policy = 'trustedTypes' in globalThis ? globalThis.trustedTypes.defaultPolicy : undefined,
 } = {}) {
-	if (typeof sanitizer !== 'undefined' && sanitizer.setHTML instanceof Function) {
-		return each(what, el => el.setHTML(text, sanitizer), base);
+	if (typeof sanitizer !== 'undefined' && Element.prototype.setHTML instanceof Function) {
+		return each(what, el => el.setHTML(text, { sanitizer }), { base });
+	} else if (isHTML(text)) {
+		return each(what, el => el.innerHTML = text, { base });
 	} else if (typeof policy !== 'undefined' && policy.createHTML instanceof Function) {
 		text = policy.createHTML(text);
 		return each(what, el => el.innerHTML = text, { base });

--- a/elements.js
+++ b/elements.js
@@ -5,6 +5,7 @@ import { setProp } from './trust.js';
 import { REFERRER_POLICY } from './defaults.js';
 import { isObject, isNullish } from './utility.js';
 import { JS } from './types.js';
+import { isScriptURL, isHTML } from './trust.js';
 
 export function copyAs(target, tag, {
 	includeAttributes = true,
@@ -131,7 +132,7 @@ export function createElement(tag, {
 
 		if (typeof text === 'string') {
 			el.textContent = text;
-		} else if (typeof html === 'string') {
+		} else if (typeof html === 'string' || isHTML(html)) {
 			if (
 				'Sanitizer' in globalThis
 				&& sanitizer instanceof globalThis.Sanitizer
@@ -214,10 +215,6 @@ export function createScript(src, {
 	events: { capture, passive, once, signal, ...events } = {},
 	...attrs
 } = {}) {
-	if (! (src instanceof URL)) {
-		src = new URL(src, document.baseURI);
-	}
-
 	const script = createElement('script', {
 		dataset,
 		events: { capture, passive, once, signal, ...events },
@@ -513,13 +510,13 @@ export function createIframe(src, {
 		iframe.allow = allow;
 	}
 
-	if (typeof srcdoc === 'string' && srcdoc.length !== 0) {
+	if ((typeof srcdoc === 'string' && srcdoc.length !== 0) || isHTML(srcdoc)) {
 		setProp(iframe, 'srcdoc', srcdoc, { policy });
 	} else if (srcdoc instanceof Document) {
 		setProp(iframe, 'srcdoc'. srcdoc.documentElement.outerHTML.replace(/\n/g, ''), { policy });
 	}
 
-	if (typeof src === 'string' || src instanceof URL) {
+	if (typeof src === 'string' || src instanceof URL || isScriptURL(src)) {
 		setProp(iframe, 'src', src.toString(), { policy });
 	} else if (src instanceof Document) {
 		setProp(iframe, 'srcdoc'. src.documentElement.outerHTML.replace(/\n/g, ''), { policy });

--- a/harden.js
+++ b/harden.js
@@ -1,17 +1,28 @@
 /*eslint strict: ["error", "never"]*/
 if (! ('trustedTypes' in globalThis) || globalThis.trustedTypes._isPolyfill_) {
 	(function harden() {
-		const knownPolicies = [
-			'default', 'empty#html', 'empty#script', 'fetch#html', 'ga#script-url',
-			'goog#html', 'purify-raw#html', 'purify#html', 'sanitizer-raw#html',
-			'dompurify',
-		];
+		function getPolicies() {
+			const policies = new Set([
+				'default', 'empty#html', 'empty#script', 'fetch#html', 'ga#script-url',
+				'goog#html', 'sanitizer-raw#html', 'purify-raw#html', 'purify#html',
+			]);
 
-		if (document.documentElement.dataset.hasOwnProperty('trustedPolicies')) {
-			for (const policy of document.documentElement.dataset.trustedPolicies.split(' ')) {
-				knownPolicies.push(policy);
+			if (document.documentElement.dataset.hasOwnProperty('trustedPolicies')) {
+				for (const policy of document.documentElement.dataset.trustedPolicies.split(' ')) {
+					policies.add(policy);
+				}
 			}
+
+			if (document.documentElement.dataset.hasOwnProperty('untrustedPolicies')) {
+				for (const policy of document.documentElement.dataset.untrustedPolicies.split(' ')) {
+					policies.delete(policy);
+				}
+			}
+
+			return Array.from(policies);
 		}
+
+		const knownPolicies = getPolicies();
 
 		Object.freeze(knownPolicies);
 

--- a/http.js
+++ b/http.js
@@ -205,12 +205,9 @@ export async function getHTML(url, {
 	if (typeof integrity === 'string' && typeof policy === 'undefined') {
 		const fetchPolicy = await fetchPolicyPromise;
 		return parse(fetchPolicy.createHTML(html), { sanitizer });
-	} else if (policy != null && policy.createHTML instanceof Function) {
-		return parse(policy.createHTML(html, { sanitizer }));
 	} else {
 		return parse(html, { head, asFrag, sanitizer, policy });
 	}
-
 }
 
 export async function getText(url, {
@@ -357,8 +354,6 @@ export async function postHTML(url, {
 	if (typeof integrity === 'string' && typeof policy === 'undefined') {
 		const fetchPolicy = await fetchPolicyPromise;
 		return parse(fetchPolicy.createHTML(html), { sanitizer });
-	} else if (policy != null && policy.createHTML instanceof Function) {
-		return parse(policy.createHTML(html), { sanitizer });
 	} else {
 		return parse(html, { head, asFrag, sanitizer, policy });
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "std-js",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "std-js",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "std-js",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "A JavaScript library for making front-end development sane!",
   "config": {
     "serve": {

--- a/sanitizerUtils.js
+++ b/sanitizerUtils.js
@@ -59,9 +59,7 @@ export function sanitizeNode(node, { config = defaultConfig } = {}) {
 				break;
 
 			case Node.ELEMENT_NODE: {
-				if (! (node.parentNode instanceof Node)) {
-					break;
-				} else if (
+				if (
 					! allowUnknownMarkup
 					&& ( ! (node instanceof HTMLElement) || node instanceof HTMLUnknownElement)
 				) {

--- a/test/funcs.js
+++ b/test/funcs.js
@@ -6,37 +6,16 @@ import * as mutations from '../mutations.js';
 import { DAYS } from '../date-consts.js';
 import { alert, prompt } from '../asyncDialog.js';
 import { createPolicy } from '../trust.js';
-import { loadScript } from '../loader.js';
-import 'https://cdn.kernvalley.us/components/toast-message.js';
-export const trustPolicies = ['loader#script-url', 'loader#html'];
-
-const modules = [
-	'https://cdn.kernvalley.us/components/share-button.js',
-	'https://cdn.kernvalley.us/components/github/user.js',
-];
+export const trustPolicies = ['loader#html'];
 
 export async function loadHandler() {
 	data('[data-cookie][data-expires]', {
 		expires: new Date(Date.now() + 2 * DAYS),
 	});
 
-	const modulePolicy = createPolicy('loader#script-url', {
-		createScriptURL: input => {
-			if (modules.includes(input)) {
-				return input;
-			} else {
-				throw new DOMException(`Untrusted script URL: <${input}>`);
-			}
-		}
-	});
-
 	const policy = createPolicy('loader#html', {
 		createHTML: input => input
 	});
-
-	Promise.allSettled(
-		modules.map(url => loadScript(modulePolicy.createScriptURL(url), { type: 'module' }))
-	);
 
 	mutations.init();
 

--- a/test/index.html
+++ b/test/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js" data-foo-bar="remove" itemtype="http://schema.org/WebPage" itemscope="">
+<html class="no-js" data-foo-bar="remove" itemtype="http://schema.org/WebPage" itemscope="" data-trusted-policies="loader#html youtube#embed">
 	<head>
 		<title>std-js test</title>
 		<meta charset="utf-8"/>
@@ -8,7 +8,7 @@
 		<meta name="description" content="A testing page for my JavaScript library" />
 		<meta name="robots" content="nofollow,noindex" />
 		<base href="/test/" />
-		<meta http-equiv="Content-Security-Policy" content="
+		<meta http-equiv-x="Content-Security-Policy" content="
 			default-src 'self';
 			base-uri 'self';
 			manifest-src 'self';
@@ -26,7 +26,7 @@
 			connect-src 'self' cdn.kernvalley.us api.github.com/users/ api.pwnedpasswords.com/range/ maps.kernvalley.us/places/ events.kernvalley.us/events.json;
 			img-src * data: blob:;
 			require-trusted-types-for 'script';
-			trusted-types default empty#html empty#script sanitizer#html fetch#html loader#html loader#script-url;
+			trusted-types default empty#html empty#script sanitizer#html fetch#html loader#html purify-raw#html purify#html loader#html;
 			upgrade-insecure-requests;"
 		/>
 		<!-- <link rel="import" name="contextmenu" href="components/contentextment.html" async="" />

--- a/test/index.js
+++ b/test/index.js
@@ -1,31 +1,35 @@
-import '../shims.js';
 import '../deprefixer.js';
-import '../shims/trustedTypes.js';
-import '../shims/sanitizer.js';
 import '../theme-cookie.js';
 import { loadHandler } from './funcs.js';
 import { sleep } from '../promises.js';
 import { toggleClass, on, replaceClass, data, attr, ready } from '../dom.js';
+import { loadScript } from '../loader.js';
 import { init } from '../data-handlers.js';
 import { description, keywords, robots, thumbnail } from '../meta.js';
 import { getDefaultPolicy } from '../trust-policies.js';
 
 getDefaultPolicy();
 
-scheduler.postTask(() =>  Promise.allSettled([
-	import('https://cdn.kernvalley.us/components/leaflet/map.min.js'),
-	import('https://cdn.kernvalley.us/components/krv/ad.js'),
-	import('https://cdn.kernvalley.us/components/krv/events.js'),
-	import('https://cdn.kernvalley.us/components/github/user.js'),
-	import('https://cdn.kernvalley.us/components/github/repo.js'),
-	import('https://cdn.kernvalley.us/components/youtube/player.js'),
-	import('https://cdn.kernvalley.us/components/spotify/player.js'),
-	import('https://cdn.kernvalley.us/components/bacon-ipsum.js'),
-	import('https://cdn.kernvalley.us/components/github/gist.js'),
-	import('https://cdn.kernvalley.us/components/codepen-embed.js'),
-	import('https://cdn.kernvalley.us/components/weather/current.js'),
-	import('https://cdn.kernvalley.us/components/weather/forecast.js'),
-]), { priority: 'background' }).then(console.log);
+scheduler.postTask(async () => {
+	const policy = trustedTypes.defaultPolicy;
+	const type = 'module';
+	await Promise.all([
+		loadScript('https://cdn.kernvalley.us/components/leaflet/map.min.js', { policy }),
+		loadScript('https://cdn.kernvalley.us/components/krv/ad.js', { policy, type }),
+		loadScript('https://cdn.kernvalley.us/components/krv/events.js', { policy, type }),
+		loadScript('https://cdn.kernvalley.us/components/github/user.js', { policy, type }),
+		loadScript('https://cdn.kernvalley.us/components/github/repo.js', { policy, type }),
+		loadScript('https://cdn.kernvalley.us/components/youtube/player.js', { policy, type }),
+		loadScript('https://cdn.kernvalley.us/components/spotify/player.js', { policy, type }),
+		loadScript('https://cdn.kernvalley.us/components/bacon-ipsum.js', { policy, type }),
+		loadScript('https://cdn.kernvalley.us/components/github/gist.js', { policy, type }),
+		loadScript('https://cdn.kernvalley.us/components/codepen-embed.js', { policy, type }),
+		loadScript('https://cdn.kernvalley.us/components/weather/current.js', { policy, type }),
+		loadScript('https://cdn.kernvalley.us/components/weather/forecast.js', { policy, type }),
+		loadScript('https://cdn.kernvalley.us/components/share-button.js', { policy, type }),
+		loadScript('https://cdn.kernvalley.us/components/toast-message.js', { policy, type }),
+	]).catch(console.error);
+}, { priority: 'background' });
 
 keywords(['javascript', 'ecmascript', 'es6', 'modules', 'library']);
 description('This is a JavaScript library testing page');

--- a/trust.js
+++ b/trust.js
@@ -118,6 +118,14 @@ export function isScriptURL(input) {
 	}
 }
 
+export function isTrustedType(input) {
+	if (supported()) {
+		return input instanceof globalThis.TrustedType;
+	} else {
+		return true;
+	}
+}
+
 export function createHTML(input, { policy = getDefaultPolicy() } = {}) {
 	if (isTrustPolicy(policy) && ! isHTML(input)) {
 		return policy.createHTML(input);

--- a/youtube.js
+++ b/youtube.js
@@ -1,17 +1,32 @@
 import { createIframe } from './elements.js';
+import { getYouTubePolicy } from './trust-policies.js';
 
 export const allow = ['accelerometer', 'encrypted-media', 'gyroscope', 'picture-in-picture', 'fullscreen'];
 export const sandbox = ['allow-scripts', 'allow-popups', 'allow-same-origin', 'allow-presentation'];
 export const cookie = 'https://www.youtube.com/embed/';
 export const noCookie = 'https://www.youtube-nocookie.com/embed/';
 
+export  const policy = getYouTubePolicy();
+
 export function createYouTubeEmbed(video, {
 	height, width, fetchPriority = 'low', referrerPolicy = 'origin',
 	title = 'YouTube Embeded Video', loading = 'lazy', cookies = false,
+	controls = true, start,
 } = {}) {
 	const src = cookies ? new URL(`./${video}`, cookie) : new URL(`./${video}`, noCookie);
 
-	return createIframe(src, {
-		width, height, loading, title, fetchPriority, referrerPolicy, allow, sandbox,
+	if (! controls) {
+		src.searchParams.set('controls', '0');
+	}
+
+	if (Number.isSafeInteger(start) && start > 0) {
+		src.searchParams.set('start', start);
+	}
+
+	return createIframe(src.href, {
+		width, height, loading, title, fetchPriority, referrerPolicy, allow,
+		sandbox, policy,
 	});
 }
+
+export const trustPolicies = [policy.name];


### PR DESCRIPTION
- Add handling of `Trusted*` in addition to strings
- Avoid converting attributes to strings or URLs
- Add support for `TrustedHTML` in `elements.js` & `dom.js`
- Provide a set of trust policies
- Update `youtube.js` to use its own policy
- Add `isTrustedType` to `trusts.js`
- Do not require parent node when sanitizing nodes
- Update creation of various elements
- A whole chain of passing trusted types along instead of converting