### PR TITLE
Fix invalid `createScript` in GA policy

### DIFF
--- a/trust-policies.js
+++ b/trust-policies.js
@@ -166,9 +166,10 @@ export const getYouTubePolicy = callOnce(() => createPolicy('youtube#embed', {
 		}
 	}
 }));
+
 export const getGooglePolicy = callOnce(() => createPolicy('ga#script-url', {
 	createHTML: () => trustedTypes.emptyHTML,
-	createScript: trustedTypes.emptyScript,
+	createScript: () => trustedTypes.emptyScript,
 	createScriptURL: input => {
 		const url = new URL(input, document.baseURI);
 
@@ -179,3 +180,5 @@ export const getGooglePolicy = callOnce(() => createPolicy('ga#script-url', {
 		}
 	}
 }));
+
+export const getDefaultNoOpPolicy = callOnce(() => createPolicy('default', {}));


### PR DESCRIPTION
Also adds option to create a no-op default policy for complete lockdown.

# Description and issue

## List of significant changes made
-  
-  
