### PR TITLE
Add option to use CSP for `TrustedTypes` polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- By default attempts to load CSP from `<meta http-equiv>`
+- Has option to fetch page and look at CSP headers
+- Fallback is still using `[data-trusted-policies]`
+- Rewrite disqus module to use current `disqus#script-url` policy
+
+### Added
+- Add new pre-made policies
+- Add helper methods for creating polices
+- Add methods to get CSP in `http.js`
+
+### Removed
+- Remove obsolete `fetch#html` policy from `http.js`
+
 ## [v2.7.2] - 2023-03-03
 
 ### Added

--- a/test/funcs.js
+++ b/test/funcs.js
@@ -2,10 +2,11 @@ import { $ } from '../esQuery.js';
 import { getJSON } from '../http.js';
 import handleJSON from '../json_response.js';
 import { on, data } from '../dom.js';
-import * as mutations from '../mutations.js';
+import { events, options, filter, init } from '../mutations.js';
 import { DAYS } from '../date-consts.js';
 import { alert, prompt } from '../asyncDialog.js';
-import { createPolicy } from '../trust.js';
+import { createHTMLPolicyGetter } from '../trust.js';
+
 export const trustPolicies = ['loader#html'];
 
 export async function loadHandler() {
@@ -13,13 +14,11 @@ export async function loadHandler() {
 		expires: new Date(Date.now() + 2 * DAYS),
 	});
 
-	const policy = createPolicy('loader#html', {
-		createHTML: input => input
-	});
+	const policy = createHTMLPolicyGetter('loader#html', input => input)();
 
-	mutations.init();
+	init();
 
-	$(document.body).watch(mutations.events, mutations.options, mutations.filter);
+	$(document.body).watch(events, options, filter);
 
 	on('#set-cookie', 'click', async () => {
 		const name = await prompt('Enter cookie name');

--- a/test/index.html
+++ b/test/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js" data-foo-bar="remove" itemtype="http://schema.org/WebPage" itemscope="" data-trusted-policies="empty#html empty#script default sanitizer-raw#html loader#html purify-raw#html purify#html loader#html weather-forecast#html weather-current#html youtube#embed github#gist codepen#script-url">
+<html class="no-js" data-foo-bar="remove" itemtype="http://schema.org/WebPage" itemscope="">
 	<head>
 		<title>std-js test</title>
 		<meta charset="utf-8"/>
@@ -8,7 +8,7 @@
 		<meta name="description" content="A testing page for my JavaScript library" />
 		<meta name="robots" content="nofollow,noindex" />
 		<base href="/test/" />
-		<meta http-equiv-x="Content-Security-Policy" content="
+		<meta http-equiv="Content-Security-Policy" content="
 			default-src 'self';
 			base-uri 'self';
 			manifest-src 'self';
@@ -26,7 +26,7 @@
 			connect-src 'self' cdn.kernvalley.us api.github.com/users/ api.pwnedpasswords.com/range/ maps.kernvalley.us/places/ events.kernvalley.us/events.json;
 			img-src * data: blob:;
 			require-trusted-types-for 'script';
-			trusted-types empty#html empty#script default sanitizer-raw#html loader#html purify-raw#html purify#html loader#html weather-forecast#html weather-current#html youtube#embed github#gist codepen#script-url;
+			trusted-types empty#html empty#script default sanitizer-raw#html loader#html purify-raw#html purify#html loader#html weather-forecast#html weather-current#html youtube#embed github#gist codepen#script-url krv-events#html disqus#script-url 'allow-duplicates';
 			upgrade-insecure-requests;"
 		/>
 		<!-- <link rel="import" name="contextmenu" href="components/contentextment.html" async="" />

--- a/test/index.js
+++ b/test/index.js
@@ -6,11 +6,11 @@ import { toggleClass, on, replaceClass, data, attr, ready } from '../dom.js';
 import { loadScript } from '../loader.js';
 import { init } from '../data-handlers.js';
 import { description, keywords, robots, thumbnail } from '../meta.js';
-import { getDefaultPolicy } from '../trust-policies.js';
+import { getDefaultPolicyWithDisqus } from '../trust-policies.js';
 import { errorHandler } from '../err-modal-report.js';
 globalThis.addEventListener('error', errorHandler);
 
-getDefaultPolicy();
+getDefaultPolicyWithDisqus();
 
 scheduler.postTask(async () => {
 	const policy = trustedTypes.defaultPolicy;
@@ -43,7 +43,7 @@ toggleClass(document.documentElement, {
 	'no-details': document.createElement('details') instanceof HTMLUnknownElement,
 	'js': true,
 	'no-js': false,
-	'no-custom-elements': !('customElements' in window),
+	'no-custom-elements': !('customElements' in globalThis),
 });
 
 init();

--- a/trust.js
+++ b/trust.js
@@ -1,5 +1,6 @@
 import { getDeferred } from './promises.js';
 import { listen } from './events.js';
+import { callOnce } from './utility.js';
 
 export function setProp(el, prop, val, {
 	policy,
@@ -194,3 +195,9 @@ export async function whenPolicyCreated(name = 'default', { signal } = {}) {
 
 	return promise;
 }
+
+export const createHTMLPolicyGetter = (name, cb) => callOnce(() => createPolicy(name, { createHTML: cb }));
+
+export const createScriptPolicyGetter = (name, cb) => callOnce(() => createPolicy(name, { createScript: cb }));
+
+export const createScriptURLPolicyGetter = (name, cb) => callOnce(() => createPolicy(name, { createScriptURL: cb }));


### PR DESCRIPTION
- By default attempts to load CSP from `<meta http-equiv>`
- Has option to fetch page and look at CSP headers
- Fallback is still using `[data-trusted-policies]`
- Add new pre-made policies
- Add helper methods for creating polices
- Remove obsolete `fetch#html` policy from `http.js`
- Add methods to get CSP in `http.js`
- Rewrite disqus module to use current `disqus#script-url` policy
- Misc fixes
