### PR TITLE
Add `ElementInternals` polyfill

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
     "extends": "eslint:recommended",
     "parserOptions": {
         "sourceType": "module",
-        "ecmaVersion": 2020,
+        "ecmaVersion": 2022,
         "impliedStrict": false
     },
     "plugins": [],

--- a/Sanitizer.js
+++ b/Sanitizer.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2022-2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { nativeSupport, getSantizerUtils, sanitize, sanitizeFor, trustPolicies } from './sanitizerUtils.js';
 import { SanitizerConfig as defaultConfig } from './SanitizerConfigW3C.js';
 

--- a/attributes.js
+++ b/attributes.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2023 Chris Zuber <admin@kernvalley.us>
+ */
 export const events = Object.keys(
 	Object.getOwnPropertyDescriptors(HTMLElement.prototype)
 ).filter(desc => desc.startsWith('on'));

--- a/attrs.js
+++ b/attrs.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { clamp, between } from './math.js';
 import { isObject } from './utility.js';
 import { setAttr, isScriptURL, isTrustedType } from './trust.js';

--- a/dom.js
+++ b/dom.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2021-2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { signalAborted } from './abort.js';
 import { addListener, listen, loaded as whenLoaded } from './events.js';
 import { getDeferred, isAsync } from './promises.js';

--- a/elements.js
+++ b/elements.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { data, attr, css, getAttrs } from './attrs.js';
 import { listen } from './events.js';
 import { getDeferred } from './promises.js';

--- a/geo.js
+++ b/geo.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2021-2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { getDeferred } from './promises.js';
 
 export const supported = 'geolocation' in navigator;

--- a/google-analytics.js
+++ b/google-analytics.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2021-2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { loadScript } from './loader.js';
 export const trustPolicies = ['goog#html'];
 

--- a/harden.js
+++ b/harden.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2023 Chris Zuber <admin@kernvalley.us>
+ */
 /*eslint strict: ["error", "never"]*/
 if (! ('trustedTypes' in globalThis) || globalThis.trustedTypes._isPolyfill_) {
 	(function harden() {

--- a/hash.js
+++ b/hash.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2021-2023 Chris Zuber <admin@kernvalley.us>
+ */
 export const SHA_1          = 'SHA-1';
 export const SHA_256        = 'SHA-256';
 export const SHA_384        = 'SHA-384';

--- a/htmlpurify.js
+++ b/htmlpurify.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2022-2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { createPolicy } from './trust.js';
 import { events } from './attributes.js';
 import { sanitize } from './sanitizerUtils.js';

--- a/http.js
+++ b/http.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2021-2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { parse } from './dom.js';
 import { signalAborted } from './abort.js';
 import { setURLParams, setUTMParams, isObject, isNullish, callOnce } from './utility.js';

--- a/icons.js
+++ b/icons.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2023 Chris Zuber <admin@kernvalley.us>
+ */
 import {
 	createSVG, createPath, createGroup, createCircle, createRect, translate, rotate,
 } from './svg.js';

--- a/img-utils.js
+++ b/img-utils.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { getDeferred } from './promises.js';
 import { createElement } from './elements.js';
 import { JPEG, PNG, GIF, WEBP, SVG } from './types.js';

--- a/loader.js
+++ b/loader.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { JS } from './types.js';
 import { createScript, createImage, createLink } from './elements.js';
 import { getDeferred } from './promises.js';

--- a/namespaces.js
+++ b/namespaces.js
@@ -1,2 +1,4 @@
+export const HTML = 'http://www.w3.org/1999/xhtml';
 export const SVG = 'http://www.w3.org/2000/svg';
 export const XLINK = 'http://www.w3.org/1999/xlink';
+export const MATHML = 'http://www.w3.org/1998/Math/MathML';

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "scripts": {
     "test": "npm run lint:js && npm run lint:html",
     "preversion": "npm test",
-    "start": "http-server ${npm_package_config_serve_path} --port ${npm_package_config_serve_port} --gzip true --brotli true -a ${npm_package_config_serve_domain} -o /test/",
+    "start": "http-server ${npm_package_config_serve_path} -c-1 --port ${npm_package_config_serve_port} --gzip true --brotli true -a ${npm_package_config_serve_domain} -o /test/",
     "fix": "npm run fix:js",
     "fix:js": "eslint . --fix",
     "lint:js": "eslint .",

--- a/pwned.js
+++ b/pwned.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2021-2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { sha1, HEX } from './hash.js';
 import { getText } from './http.js';
 import { listen } from './events.js';

--- a/shims/elementInternals.js
+++ b/shims/elementInternals.js
@@ -2,6 +2,16 @@
  * @see https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals
  * @see https://caniuse.com/mdn-api_formdataevent
  * @see https://caniuse.com/mdn-api_elementinternals
+ * @todo: Use MutationObserver to deal with `disabled` on custom els & their fieldsets
+ *
+ * This polyfill needs a bit of extra work from the custom element to work.
+ * Check if `internals._polyfilled` to see if extra steps are necessary:
+ * - Call `internals._associateForm(form, this)` in `connectedCallback()`
+ * - Add `disabled` to `observedAttributes()`
+ * - Call `this.formDisabledCallback(typeof newVal === 'string')` from `attributeChangedCallback()`
+ *
+ * Additionally, if `internals.states._polyfilled`
+ * - Use `._state--*` in addition to `:--*` to query element internals states
  */
 if (! (HTMLElement.prototype.attachInternals instanceof Function) && 'FormDataEvent' in globalThis) {
 	const symbols = {

--- a/slack.js
+++ b/slack.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { sha256 } from './hash.js';
 import { POST } from './http.js';
 

--- a/svg.js
+++ b/svg.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2022-2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { SVG, XLINK } from './namespaces.js';
 import { isObject } from './utility.js';
 import { css, data, attr } from './attrs.js';

--- a/trust-policies.js
+++ b/trust-policies.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { createPolicy } from './trust.js';
 import { callOnce } from './utility.js';
 import {

--- a/trust.js
+++ b/trust.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { getDeferred } from './promises.js';
 import { listen } from './events.js';
 import { callOnce } from './utility.js';

--- a/types.js
+++ b/types.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2023 Chris Zuber <admin@kernvalley.us>
+ */
 export const TEXT = 'text/plain';
 export const HTML = 'text/html';
 export const CSS = 'text/css';

--- a/utility.js
+++ b/utility.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { randomInt } from './math.js';
 import { isAsyncFunction, getDeferred } from './promises.js';
 import { isScriptURL, isTrustPolicy } from './trust.js';

--- a/utility.js
+++ b/utility.js
@@ -221,6 +221,7 @@ export function deepEquals(thing1, thing2, { depth = 5 } = {}) {
 			case 'Number':
 			case 'String':
 			case 'Symbol':
+			case 'Boolean':
 				// Already know not equal
 				return false;
 

--- a/youtube.js
+++ b/youtube.js
@@ -1,3 +1,6 @@
+/**
+ * @copyright 2023 Chris Zuber <admin@kernvalley.us>
+ */
 import { createIframe } from './elements.js';
 import { getYouTubePolicy } from './trust-policies.js';
 


### PR DESCRIPTION
Also adds copyright to some scripts.

**Note**:
- `internals.states.add('--foo')` uses `._state--foo` instead of `:--foo`
- `:disabled` & `:invalid` are states, thus become `._state--disabled` & `._state--invalid`
- Associating a component to a form requires calling `internals._associateForm(form, this)` such as in `connectedCallback()`
- `MutationObserver` is used and does not have an `unobserve()` method, so junk can accumulate in complex usage
- Call `internals._associateForm(null, this)` in a `disconnectedCallback()` if needed
- `formStateRestoreCallback()` cannot realistically be polyfilled
- There is no built-in behavior when disabling elements - use `formDisabledCallback()`
- `internals._polyfilled` is set to true for checking if the additional steps are necessary
- `:--foo` is an invalid selector unless `CustomStateSet` is supported, so `:--foo, ._state--foo` won't work