### PR TITLE
Fix `createPolicy`()` in trust module and `sigma()` in math module

### DIFF
--- a/math.js
+++ b/math.js
@@ -77,7 +77,7 @@ export function* rng({ length = 32 } = {}) {
 }
 
 export function sigma(start, end, callback) {
-	return Array.from(range(start, end)).reduce((sum, num) => sum + callback(num));
+	return Iterator.range(start, end).map(callback).reduce((sum, n) => sum + n);
 }
 
 export function sum(...nums) {

--- a/spotify.js
+++ b/spotify.js
@@ -1,0 +1,108 @@
+import { createPolicy } from './trust.js';
+import { createIframe } from './elements.js';
+
+const SPOTIFY = 'https://open.spotify.com/embed/';
+const SANDBOX = ['allow-scripts', 'allow-popups', 'allow-same-origin'];
+const ALLOW = ['encrypted-media'];
+const TYPES = [
+	'album',
+	'artist',
+	'playlist',
+	'show',
+	'track',
+];
+
+export const policy = createPolicy('spotify#script-url', {
+	createScriptURL: input => {
+		if (input.startsWith(SPOTIFY)) {
+			return input;
+		} else {
+			throw new TypeError(`Not a Spotify embed URL: ${input}`);
+		}
+	}
+});
+
+export function parseURI(uri) {
+	if (typeof uri !== 'string') {
+		throw new Error('URI is not a string');
+	} else if (! uri.startsWith('spotify:')) {
+		throw new Error('URI is not a valid Spotify URI');
+	} else {
+		const [, type = '', id = ''] = uri.split(':');
+
+		if (! TYPES.includes(type)) {
+			throw new Error(`Unsupported type: ${type}`);
+		} else {
+			return { type, id };
+		}
+	}
+}
+
+export function linkToUri(link) {
+	if (typeof link === 'string' && link.startsWith('https:')) {
+		const url = new URL(link);
+		const [type = null, id = null] = url.pathname.substr(1).split('/');
+
+		if (
+			url.host.toLowerCase() === 'open.spotify.com'
+			&& TYPES.includes(type)
+			&& typeof id === 'string'
+		) {
+			return `spotify:${type}:${id}`;
+		} else {
+			return null;
+		}
+	} else {
+		return null;
+	}
+}
+
+export function uriToLink(uri) {
+	if (typeof uri === 'string' && uri.startsWith('spotify:')) {
+		const [, type = null, id = null] = uri.split(':');
+
+		if (TYPES.includes(type) && typeof id === 'string') {
+			const url = new URL(`${type}/${id}`, 'https://open.spotify.com');
+			return url.href;
+		} else {
+			return null;
+		}
+	} else {
+		return null;
+	}
+}
+
+function createSpotifyIframe(type, id, { title = 'Spotify Player', large = false, slot, part } = {}) {
+	return createIframe(policy.createScriptURL(new URL(`./${type}/${id}`, SPOTIFY)), {
+		width: 300,
+		height: large ? 380 : 80,
+		referrerPolicy: 'origin',
+		slot,
+		part,
+		sandbox: SANDBOX,
+		allow: ALLOW,
+		title,
+	});
+}
+
+export function createSpotifyAlbum(id, { title, large, slot, part } = {}) {
+	return createSpotifyIframe('album', id, { title, large, slot, part });
+}
+
+export function createSpotifyArtist(id, { title, large, slot, part } = {}) {
+	return createSpotifyIframe('artist', id, { title, large, slot, part });
+}
+
+export function createSpotifyPlaylist(id, { title, large, slot, part } = {}) {
+	return createSpotifyIframe('playlist', id, { title, large, slot, part });
+}
+
+export function createSpotifyShow(id, { title, large, slot, part } = {}) {
+	return createSpotifyIframe('show', id, { title, large, slot, part });
+}
+
+export function createSpotifyTrack(id, { title, large, slot, part } = {}) {
+	return createSpotifyIframe('track', id, { title, large, slot, part });
+}
+
+export const trustPolicies = [policy.name];

--- a/trust.js
+++ b/trust.js
@@ -1,5 +1,3 @@
-import { getDeferred } from './promises.js';
-import { listen } from './events.js';
 import { callOnce } from './utility.js';
 
 export function setProp(el, prop, val, {


### PR DESCRIPTION
Also adds Spotify embed creating module with `spotify#script-url` trust policy.

Also removes `whenPolicyCreated()` since policy creation events have been removed.