### PR TITLE
Fix issue setting attributes 

### DIFF
--- a/attrs.js
+++ b/attrs.js
@@ -89,7 +89,7 @@ export function attr(el, props = {}, {
 		Object.entries(props).forEach(([p, v]) => {
 			if (typeof v === 'string' || typeof v === 'number') {
 				setAttr(el, p, v, { policy, elementNs });
-			} else if (isTrustedType(v)) {
+			} else if ('trustedTypes' in globalThis && isTrustedType(v)) {
 				if (v.toString().length === 0) {
 					el.removeAttribute(p);
 				} else {

--- a/share-init.js
+++ b/share-init.js
@@ -1,0 +1,44 @@
+import { each } from './dom.js';
+import { listen } from './events.js';
+import { createPublicShareIcon } from './icons.js';
+import { createElement } from './elements.js';
+
+export const supported = navigator.share instanceof Function;
+export const selector = 'button[data-share-title], button[data-share-text], button[data-share-url]';
+
+export async function shareHandler({ currentTarget }) {
+	const { shareTitle: title, shareText: text, shareUrl: url } = currentTarget.dataset;
+	await navigator.share({ title, text, url });
+}
+
+export function shareInit({ base = document, signal, event = 'click', once = false } = {}) {
+	if (supported) {
+		each(selector, el => {
+			listen(el, event, shareHandler, { signal, once });
+			el.disabled = false;
+			el.hidden = false;
+		}, { base });
+	} else {
+		each(selector, el => el.disabled = true, { base });
+	}
+}
+
+export function createShareButton({
+	title: shareTitle = document.title,
+	url: shareUrl = location.href,
+	text: shareText,
+	classList = ['btn', 'btn-primary'],
+	iconSize: size = 20,
+	part,
+	slot,
+	signal,
+} = {}) {
+	return createElement('button', {
+		type: 'button',
+		classList, slot, part,
+		disabled: ! supported,
+		dataset: { shareTitle, shareUrl, shareText },
+		events: { click: shareHandler, signal },
+		children: [createPublicShareIcon({ size, fill: 'currentColor' })],
+	});
+}


### PR DESCRIPTION
When trusted types are not supported, `isTrustedType()` returns true for compatibility reasons. So, when using `attr()` without trusted types support, this breaks setting all non-string values.

Also adds module to help using share API.