### PR TITLE
Auto clone frag when getting templates

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -6,7 +6,6 @@ import { createScript, createImage, createLink } from './elements.js';
 import { getDeferred } from './promises.js';
 import { getHTML } from './http.js';
 import { callOnce } from './utility.js';
-import { REFERRER_POLICY } from './defaults.js';
 
 /**
  * @deprecated
@@ -17,17 +16,22 @@ export async function loadLink(...args) {
 }
 
 export function getTemplateLoader(url, {
-	policy = 'trustedTypes' in globalThis ? trustedTypes.defaultPolicy : null,
+	mode = 'cors',
+	credentials = 'omit',
 	cache = 'default',
 	redirect = 'follow',
+	referrerPolicy = 'no-referrer',
 	integrity = undefined,
-	referrerPolicy = REFERRER_POLICY,
 	priority = 'auto',
+	policy = 'trustedTypes' in globalThis ? trustedTypes.defaultPolicy : null,
 	sanitizer,
 } = {}) {
-	return callOnce(async ({ signal } = {}) => getHTML(url, {
-		signal, policy, sanitizer, cache, redirect, integrity, referrerPolicy, priority,
+	const getTmp = callOnce(async ({ signal } = {}) => getHTML(url, {
+		signal, policy, sanitizer, cache, redirect, integrity, referrerPolicy,
+		priority, credentials, mode,
 	}));
+
+	return ({ signal } = {}) => getTmp({ signal }).then(frag => frag.cloneNode(true));
 }
 
 export async function preload(href, {


### PR DESCRIPTION
No more need to `cloneNode()` when using this.