### PR TITLE
Add polyfill for `inert`

### DIFF
--- a/keyboard.js
+++ b/keyboard.js
@@ -1,0 +1,542 @@
+export const numRow = {
+	'0': {
+		'key': '0',
+		'keyCode': 48
+	},
+	'1': {
+		'key': '1',
+		'keyCode': 49
+	},
+	'2': {
+		'key': '2',
+		'keyCode': 50
+	},
+	'3': {
+		'key': '3',
+		'keyCode': 51
+	},
+	'4': {
+		'key': '4',
+		'keyCode': 52
+	},
+	'5': {
+		'key': '5',
+		'keyCode': 53
+	},
+	'6': {
+		'key': '6',
+		'keyCode': 54
+	},
+	'7': {
+		'key': '7',
+		'keyCode': 55
+	},
+	'8': {
+		'key': '8',
+		'keyCode': 56
+	},
+	'9': {
+		'key': '9',
+		'keyCode': 57
+	}
+};
+
+export const qwerty = {
+	'`': {
+		'key': '`',
+		'keyCode': 192
+	},
+	'-': {
+		'key': '-',
+		'keyCode': 173
+	},
+	'=': {
+		'key': '=',
+		'keyCode': 61
+	},
+	'Backspace': {
+		'key': 'Backspace',
+		'keyCode': 8
+	},
+	'\\': {
+		'key': '\\',
+		'keyCode': 220
+	},
+	']': {
+		'key': ']',
+		'keyCode': 221
+	},
+	'[': {
+		'key': '[',
+		'keyCode': 219
+	},
+	'p': {
+		'key': 'p',
+		'keyCode': 80
+	},
+	'o': {
+		'key': 'o',
+		'keyCode': 79
+	},
+	'i': {
+		'key': 'i',
+		'keyCode': 73
+	},
+	'u': {
+		'key': 'u',
+		'keyCode': 85
+	},
+	'y': {
+		'key': 'y',
+		'keyCode': 89
+	},
+	't': {
+		'key': 't',
+		'keyCode': 84
+	},
+	'r': {
+		'key': 'r',
+		'keyCode': 82
+	},
+	'e': {
+		'key': 'e',
+		'keyCode': 69
+	},
+	'w': {
+		'key': 'w',
+		'keyCode': 87
+	},
+	'q': {
+		'key': 'q',
+		'keyCode': 81
+	},
+	'a': {
+		'key': 'a',
+		'keyCode': 65
+	},
+	's': {
+		'key': 's',
+		'keyCode': 83
+	},
+	'd': {
+		'key': 'd',
+		'keyCode': 68
+	},
+	'f': {
+		'key': 'f',
+		'keyCode': 70
+	},
+	'g': {
+		'key': 'g',
+		'keyCode': 71
+	},
+	'h': {
+		'key': 'h',
+		'keyCode': 72
+	},
+	'j': {
+		'key': 'j',
+		'keyCode': 74
+	},
+	'k': {
+		'key': 'k',
+		'keyCode': 75
+	},
+	'l': {
+		'key': 'l',
+		'keyCode': 76
+	},
+	';': {
+		'key': ';',
+		'keyCode': 59
+	},
+	'"': {
+		'key': '"',
+		'keyCode': 222
+	},
+	'/': {
+		'key': '/',
+		'keyCode': 191
+	},
+	'.': {
+		'key': '.',
+		'keyCode': 190
+	},
+	',': {
+		'key': ',',
+		'keyCode': 188
+	},
+	'm': {
+		'key': 'm',
+		'keyCode': 77
+	},
+	'n': {
+		'key': 'n',
+		'keyCode': 78
+	},
+	'b': {
+		'key': 'b',
+		'keyCode': 66
+	},
+	'v': {
+		'key': 'v',
+		'keyCode': 86
+	},
+	'c': {
+		'key': 'c',
+		'keyCode': 67
+	},
+	'x': {
+		'key': 'x',
+		'keyCode': 88
+	},
+	'z': {
+		'key': 'z',
+		'keyCode': 90
+	},
+	'~': {
+		'key': '~',
+		'keyCode': 192
+	},
+	'!': {
+		'key': '!',
+		'keyCode': 49
+	},
+	'@': {
+		'key': '@',
+		'keyCode': 50
+	},
+	'#': {
+		'key': '#',
+		'keyCode': 51
+	},
+	'$': {
+		'key': '$',
+		'keyCode': 52
+	},
+	'%': {
+		'key': '%',
+		'keyCode': 53
+	},
+	'^': {
+		'key': '^',
+		'keyCode': 54
+	},
+	'&': {
+		'key': '&',
+		'keyCode': 55
+	},
+	'*': {
+		'key': '*',
+		'keyCode': 56
+	},
+	'(': {
+		'key': '(',
+		'keyCode': 57
+	},
+	')': {
+		'key': ')',
+		'keyCode': 48
+	},
+	'_': {
+		'key': '_',
+		'keyCode': 173
+	},
+	'+': {
+		'key': '+',
+		'keyCode': 61
+	},
+	'|': {
+		'key': '|',
+		'keyCode': 220
+	},
+	'}': {
+		'key': '}',
+		'keyCode': 221
+	},
+	'{': {
+		'key': '{',
+		'keyCode': 219
+	},
+	'P': {
+		'key': 'P',
+		'keyCode': 80
+	},
+	'O': {
+		'key': 'O',
+		'keyCode': 79
+	},
+	'I': {
+		'key': 'I',
+		'keyCode': 73
+	},
+	'U': {
+		'key': 'U',
+		'keyCode': 85
+	},
+	'Y': {
+		'key': 'Y',
+		'keyCode': 89
+	},
+	'T': {
+		'key': 'T',
+		'keyCode': 84
+	},
+	'R': {
+		'key': 'R',
+		'keyCode': 82
+	},
+	'E': {
+		'key': 'E',
+		'keyCode': 69
+	},
+	'W': {
+		'key': 'W',
+		'keyCode': 87
+	},
+	'Q': {
+		'key': 'Q',
+		'keyCode': 81
+	},
+	'A': {
+		'key': 'A',
+		'keyCode': 65
+	},
+	'S': {
+		'key': 'S',
+		'keyCode': 83
+	},
+	'D': {
+		'key': 'D',
+		'keyCode': 68
+	},
+	'F': {
+		'key': 'F',
+		'keyCode': 70
+	},
+	'G': {
+		'key': 'G',
+		'keyCode': 71
+	},
+	'H': {
+		'key': 'H',
+		'keyCode': 72
+	},
+	'J': {
+		'key': 'J',
+		'keyCode': 74
+	},
+	'K': {
+		'key': 'K',
+		'keyCode': 75
+	},
+	'L': {
+		'key': 'L',
+		'keyCode': 76
+	},
+	':': {
+		'key': ':',
+		'keyCode': 59
+	},
+	'\'': {
+		'key': '\'',
+		'keyCode': 222
+	},
+	'?': {
+		'key': '?',
+		'keyCode': 191
+	},
+	'>': {
+		'key': '>',
+		'keyCode': 190
+	},
+	'<': {
+		'key': '<',
+		'keyCode': 188
+	},
+	'M': {
+		'key': 'M',
+		'keyCode': 77
+	},
+	'N': {
+		'key': 'N',
+		'keyCode': 78
+	},
+	'B': {
+		'key': 'B',
+		'keyCode': 66
+	},
+	'V': {
+		'key': 'V',
+		'keyCode': 86
+	},
+	'C': {
+		'key': 'C',
+		'keyCode': 67
+	},
+	'X': {
+		'key': 'X',
+		'keyCode': 88
+	},
+	'Z': {
+		'key': 'Z',
+		'keyCode': 90
+	}
+};
+
+export const other = {
+	'ScrollLock': {
+		'key': 'ScrollLock',
+		'keyCode': 145
+	},
+	'Pause': {
+		'key': 'Pause',
+		'keyCode': 19
+	},
+	'Insert': {
+		'key': 'Insert',
+		'keyCode': 45
+	},
+	'Home': {
+		'key': 'Home',
+		'keyCode': 36
+	},
+	'PageUp': {
+		'key': 'PageUp',
+		'keyCode': 33
+	},
+	'PageDown': {
+		'key': 'PageDown',
+		'keyCode': 34
+	},
+	'End': {
+		'key': 'End',
+		'keyCode': 35
+	},
+	'Delete': {
+		'key': 'Delete',
+		'keyCode': 46
+	},
+	'CapsLock': {
+		'key': 'CapsLock',
+		'keyCode': 20
+	},
+	'Control': {
+		'key': 'Control',
+		'keyCode': 17
+	},
+	'Alt': {
+		'key': 'Alt',
+		'keyCode': 18
+	},
+	'Escape': {
+		'key': 'Escape',
+		'keyCode': 27
+	},
+	'Shift': {
+		'key': 'Shift',
+		'keyCode': 16
+	},
+	'Enter': {
+		'key': 'Enter',
+		'keyCode': 13
+	},
+	'Space': {
+		'key': ' ',
+		'keyCode': 32
+	},
+	'Tab': {
+		'key': 'Tab',
+		'keyCode': 9
+	}
+};
+
+export const arrows = {
+	'ArrowUp': {
+		'key': 'ArrowUp',
+		'keyCode': 38
+	},
+	'ArrowDown': {
+		'key': 'ArrowDown',
+		'keyCode': 40
+	},
+	'ArrowLeft': {
+		'key': 'ArrowLeft',
+		'keyCode': 37
+	},
+	'ArrowRight': {
+		'key': 'ArrowRight',
+		'keyCode': 39
+	}
+};
+
+export const numPad = {
+	'0': {
+		'key': '0',
+		'keyCode': 96
+	},
+	'1': {
+		'key': '1',
+		'keyCode': 97
+	},
+	'2': {
+		'key': '2',
+		'keyCode': 98
+	},
+	'3': {
+		'key': '3',
+		'keyCode': 99
+	},
+	'4': {
+		'key': '4',
+		'keyCode': 100
+	},
+	'5': {
+		'key': '5',
+		'keyCode': 101
+	},
+	'6': {
+		'key': '6',
+		'keyCode': 102
+	},
+	'7': {
+		'key': '7',
+		'keyCode': 103
+	},
+	'8': {
+		'key': '8',
+		'keyCode': 104
+	},
+	'9': {
+		'key': '9',
+		'keyCode': 105
+	},
+	'NumLock': {
+		'key': 'NumLock',
+		'keyCode': 144
+	},
+	'/': {
+		'key': '/',
+		'keyCode': 111
+	},
+	'*': {
+		'key': '*',
+		'keyCode': 106
+	},
+	'-': {
+		'key': '-',
+		'keyCode': 109
+	},
+	'+': {
+		'key': '+',
+		'keyCode': 107
+	},
+	'.': {
+		'key': '.',
+		'keyCode': 190
+	},
+	'Enter': {
+		'key': 'Enter',
+		'keyCode': 13
+	}
+};


### PR DESCRIPTION
- Toggle `aria-hidden`
- Changes `tabindex` as needed & reverts on `el.inert = false`
- Does *not* handle elements that have `inert` preset or `el.setAttribute('inert', '')`, etc

This relies on CSS to disable pointer events, such as in:

```css
[inert] {
  pointer-events: none;
}
```

Also adds keyboard mapping module.